### PR TITLE
Fixes #4, adds endpoint validation with example, adds a case to the g…

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -11,6 +11,7 @@
     <ItemGroup>
         <PackageReference Include="Asp.Versioning.Http" Version="8.1.0" />
         <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
+        <PackageReference Include="FluentValidation" Version="11.10.0" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8"/>
         <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>

--- a/API/API.csproj
+++ b/API/API.csproj
@@ -15,6 +15,7 @@
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8"/>
         <PackageReference Include="Serilog.AspNetCore" Version="8.0.2" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
+        <PackageReference Include="System.Text.Json" Version="9.0.0-rc.2.24473.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/API/Configuration/GlobalExceptionHandler.cs
+++ b/API/Configuration/GlobalExceptionHandler.cs
@@ -19,6 +19,15 @@ public class GlobalExceptionHandler : IExceptionHandler
         _logger.LogError("Exception happend at {path} for connection id: {id}, exception trace: {type}  Message: {exception}.", path, httpContext.Connection.Id, exception.StackTrace, exception.Message);
         switch (exception)
         {
+            case BadHttpRequestException:
+                var validationResponse = new ValidationProblemDetails();
+                validationResponse.Type = "https://tools.ietf.org/html/rfc9110#section-15.5.1";
+                validationResponse.Title = "One or more validation errors occurred.";
+                validationResponse.Status = (int)HttpStatusCode.BadRequest;
+                validationResponse.Errors.Add("Error", new []{"Invalid request object"});
+                httpContext.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+                await httpContext.Response.WriteAsJsonAsync(validationResponse, cancellationToken);
+                return true;
             default:
                 errorResponse.Type = "https://datatracker.ietf.org/doc/html/rfc9110#section-15.6.1";
                 errorResponse.Title = nameof(HttpStatusCode.InternalServerError);

--- a/API/Configuration/ValidationFilter.cs
+++ b/API/Configuration/ValidationFilter.cs
@@ -11,7 +11,6 @@ public class ValidationFilter<TModel> : IEndpointFilter
     {
         _logger = logger;
         _validationFilter = validationFilter;
-
     }
 
     public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
@@ -20,6 +19,7 @@ public class ValidationFilter<TModel> : IEndpointFilter
         var result = await _validationFilter.ValidateAsync(request, context.HttpContext.RequestAborted);
         if (!result.IsValid)
         {
+            _logger.LogInformation("Validation error occured for {connectionId}", context.HttpContext.Connection.Id);
             return TypedResults.ValidationProblem(result.ToDictionary());
         }
 

--- a/API/Configuration/ValidationFilter.cs
+++ b/API/Configuration/ValidationFilter.cs
@@ -1,0 +1,36 @@
+using FluentValidation;
+
+namespace API.Configuration;
+
+public class ValidationFilter<TModel> : IEndpointFilter 
+{
+    private readonly IValidator<TModel> _validationFilter;
+    private readonly ILogger<ValidationFilter<TModel>> _logger;
+
+    public ValidationFilter(ILogger<ValidationFilter<TModel>>  logger, IValidator<TModel> validationFilter)
+    {
+        _logger = logger;
+        _validationFilter = validationFilter;
+
+    }
+
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        var request = context.Arguments.OfType<TModel>().First();
+        var result = await _validationFilter.ValidateAsync(request, context.HttpContext.RequestAborted);
+        if (!result.IsValid)
+        {
+            return TypedResults.ValidationProblem(result.ToDictionary());
+        }
+
+        return await next(context);
+    }
+}
+
+public static class ValidationFilterExtensions
+{
+    public static RouteHandlerBuilder WithRequestValidation<TModel>(this RouteHandlerBuilder builder)
+    {
+        return builder.AddEndpointFilter<ValidationFilter<TModel>>().ProducesValidationProblem();
+    }
+}

--- a/API/ExampleEndpoint.cs
+++ b/API/ExampleEndpoint.cs
@@ -1,0 +1,27 @@
+using API.Configuration;
+using Asp.Versioning;
+using Asp.Versioning.Builder;
+using Core.Example;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API;
+
+public static class ExampleEndpoint
+{
+    public static WebApplication UseExampleEndpoints(this WebApplication app)
+    {
+        ApiVersionSet apiVersionSet = app.NewApiVersionSet()
+            .HasApiVersion(new ApiVersion(1))
+            .ReportApiVersions()
+            .Build();
+        
+        var examplesV1 = app.MapGroup("v{version:apiVersion}/examples").WithApiVersionSet(apiVersionSet).WithTags("Examples");
+
+        examplesV1.MapPost("/", ([FromBody]ExampleDto dto) =>
+        {
+            TypedResults.Ok(dto);
+        }).WithRequestValidation<ExampleDto>();
+
+        return app;
+    }
+}

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -1,6 +1,5 @@
 using API.Configuration;
 using Core;
-using FluentValidation;
 using Infrastructure;
 using Infrastructure.Persistence;
 using Serilog;

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -1,5 +1,6 @@
 using API.Configuration;
 using Core;
+using FluentValidation;
 using Infrastructure;
 using Infrastructure.Persistence;
 using Serilog;
@@ -49,6 +50,7 @@ public class Program
 
         // Endpoints
         app.UseStudentEndpoints();
+        app.UseExampleEndpoints();
 
         app.Run();
     }

--- a/API/StudentEndpoints.cs
+++ b/API/StudentEndpoints.cs
@@ -22,7 +22,11 @@ public static class StudentEndpoints
             await s.HentNogleStudents();
             return TypedResults.Ok("hello");
         });
-        
+
+        studentsV1.MapPost("/", () =>
+        {
+
+        });
         
         studentsV1.MapGet("/hello", () =>
         {

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -8,6 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="FluentValidation" Version="11.10.0" />
+      <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.10.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     </ItemGroup>
 

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -13,4 +13,8 @@
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Folder Include="Shared\" />
+    </ItemGroup>
+
 </Project>

--- a/Core/Example/ExampleDto.cs
+++ b/Core/Example/ExampleDto.cs
@@ -1,0 +1,3 @@
+namespace Core.Example;
+
+public record ExampleDto(string Name, string Surname, string Email, int Age);

--- a/Core/Example/ExampleDtoValidator.cs
+++ b/Core/Example/ExampleDtoValidator.cs
@@ -18,13 +18,19 @@ public class ExampleDtoValidator : AbstractValidator<ExampleDto>
 
     }
 
-    public bool ExampleDtoValidationFilter(ExampleDto dto)
+    public bool ExampleDtoValidationFilter(ExampleDto dto, out Dictionary<string, string[]> errors)
     {
+        errors = new Dictionary<string, string[]>();
+        var firstnameErrors = new List<string>();
         if (string.IsNullOrWhiteSpace(dto.Name))
         {
-            return false;
+            firstnameErrors.Add("Name is required");
         }
+        if(firstnameErrors.Any()) errors.Add(nameof(dto.Name), firstnameErrors.ToArray());
         // ....
+        
+        if(errors.Any()) return false;
+        
         return true;
     }
 }

--- a/Core/Example/ExampleDtoValidator.cs
+++ b/Core/Example/ExampleDtoValidator.cs
@@ -1,0 +1,30 @@
+using FluentValidation;
+
+namespace Core.Example;
+
+public class ExampleDtoValidator : AbstractValidator<ExampleDto>
+{
+    public ExampleDtoValidator()
+    {
+        RuleFor(x => x.Name).NotEmpty().WithMessage("Name is required");
+        RuleFor(x => x.Name).MinimumLength(1).MaximumLength(100).WithMessage("Name must be between 1 and 100 characters");
+        RuleFor(x => x.Age).NotEmpty().WithMessage("Age is required");
+        RuleFor(x => x.Age).GreaterThan(15).WithMessage("Age must be greater than 15");
+        RuleFor(x => x.Age).LessThanOrEqualTo(100).WithMessage("Age must be less than or equal to 100");
+        RuleFor(x => x.Email).NotEmpty().WithMessage("Email is required");
+        RuleFor(x => x.Email).EmailAddress().WithMessage("Email is incorrect");
+        RuleFor(x => x.Surname).NotEmpty().WithMessage("Surname is required");
+        RuleFor(x => x.Surname).MinimumLength(1).MaximumLength(100).WithMessage("Name must be between 1 and 100 characters");
+
+    }
+
+    public bool ExampleDtoValidationFilter(ExampleDto dto)
+    {
+        if (string.IsNullOrWhiteSpace(dto.Name))
+        {
+            return false;
+        }
+        // ....
+        return true;
+    }
+}

--- a/Core/Example/ExampleDtoValidator.cs
+++ b/Core/Example/ExampleDtoValidator.cs
@@ -17,20 +17,4 @@ public class ExampleDtoValidator : AbstractValidator<ExampleDto>
         RuleFor(x => x.Surname).MinimumLength(1).MaximumLength(100).WithMessage("Name must be between 1 and 100 characters");
 
     }
-
-    public bool ExampleDtoValidationFilter(ExampleDto dto, out Dictionary<string, string[]> errors)
-    {
-        errors = new Dictionary<string, string[]>();
-        var firstnameErrors = new List<string>();
-        if (string.IsNullOrWhiteSpace(dto.Name))
-        {
-            firstnameErrors.Add("Name is required");
-        }
-        if(firstnameErrors.Any()) errors.Add(nameof(dto.Name), firstnameErrors.ToArray());
-        // ....
-        
-        if(errors.Any()) return false;
-        
-        return true;
-    }
 }

--- a/Core/RegisterCoreServices.cs
+++ b/Core/RegisterCoreServices.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Core;
@@ -6,7 +8,7 @@ public static class RegisterCoreServices
 {
     public static IServiceCollection AddCoreServices(this IServiceCollection services)
     {
-
+        services.AddValidatorsFromAssemblies(new [] {Assembly.GetExecutingAssembly() });
         services.AddScoped<StudentService>();
 
 

--- a/Core/Shared/Contracts/IValidationFilter.cs
+++ b/Core/Shared/Contracts/IValidationFilter.cs
@@ -1,0 +1,6 @@
+namespace Core.Shared.Contracts;
+
+public interface IValidationFilter<TModel>
+{
+    bool Validate(TModel model, out Dictionary<string, string[]> errors);
+}

--- a/Core/Shared/Contracts/IValidationFilter.cs
+++ b/Core/Shared/Contracts/IValidationFilter.cs
@@ -1,6 +1,0 @@
-namespace Core.Shared.Contracts;
-
-public interface IValidationFilter<TModel>
-{
-    bool Validate(TModel model, out Dictionary<string, string[]> errors);
-}


### PR DESCRIPTION
## Description

This PR add endpoint validation which can be used for the endpoints requiring data objects from the frontend. 

The PR suggest 1 of 2 methods, either using fluentvalidation or roll our own validation, choosing either will require a small rewrite of things! **Don't merge before this has been discussed!**

### Resolved Issue
Fixes #4

## Changes

The changes are as follows:
Create a validation filter that can be used with endpointfilters, this ensures we can intercept the incoming http request. Here i have added the boiler plate for either fluentvalidation or our own validation. The example running on this branch utilizes the fluentvalidation. 

Additional changes are changes to the middleware as I discovered that generating an invalid object resulted in a BadHttpRequestException, which just return a 500 internal server error, I changed this to a 400 bad request with a problem details response saying "invalid request object". 
We should consider if we are fine with this, as this means that for what ever reason asp would throw this exception will lead to this response, and I dont personally know if there could be other cases where this exact exception could be thrown, if we cant live with this we should go back to return 500.

