### PR TITLE
Bug/48

### DIFF
--- a/API/Configuration/RegisterApiConfiguration.cs
+++ b/API/Configuration/RegisterApiConfiguration.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Asp.Versioning;
+using Core.Shared;
 using Infrastructure.Authentication;
 using Infrastructure.Authentication.Models;
 using Microsoft.AspNetCore.Authentication.JwtBearer;

--- a/API/Endpoints/AuthenticationEndpoints.cs
+++ b/API/Endpoints/AuthenticationEndpoints.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Security.Claims;
 using API.Configuration;
 using API.Endpoints.Shared;
+using Core.Shared;
 using Infrastructure.Authentication.Contracts;
 using Infrastructure.Authentication.Models;
 using Microsoft.AspNetCore.Http.HttpResults;

--- a/API/Endpoints/ExerciseEndpoints.cs
+++ b/API/Endpoints/ExerciseEndpoints.cs
@@ -5,6 +5,7 @@ using Asp.Versioning.Builder;
 using Core.Contracts.Repositories;
 using Core.Contracts.Services;
 using Core.Exercises.Models;
+using Core.Shared;
 using Infrastructure.Authentication.Models;
 using Microsoft.AspNetCore.Mvc;
 

--- a/API/Endpoints/SessionEndpoints.cs
+++ b/API/Endpoints/SessionEndpoints.cs
@@ -5,6 +5,7 @@ using Asp.Versioning;
 using Asp.Versioning.Builder;
 using Core.Sessions.Contracts;
 using Core.Sessions.Models;
+using Core.Shared;
 using Infrastructure.Authentication.Models;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
@@ -24,12 +25,17 @@ public static class SessionEndpoints
             .WithTags("Sessions");
         
         // Get session
-        sessionV1Group.MapGet("/{id:int}", async Task<Results<Ok<GetSessionResponseDto>, NotFound>>(int id, ClaimsPrincipal principal, ISessionService service) =>
+        sessionV1Group.MapGet("/{id:int}", async Task<Results<Ok<GetSessionResponseDto>, NotFound, BadRequest>>(int id, ClaimsPrincipal principal, ISessionService service) =>
         {
 
             var userId = principal.FindFirst( ClaimTypes.UserData)?.Value;
-
-            var result = await service.GetSessionByIdAsync(id, Convert.ToInt32(userId));
+            var userRoles = principal.FindFirst(x => x.Type == ClaimTypes.Role)?.Value;
+            if (userRoles == null)
+            {
+                return TypedResults.BadRequest();
+            }
+            
+            var result = await service.GetSessionByIdAsync(id, Convert.ToInt32(userId), RolesConvert.Convert(userRoles));
             if (result.IsFailed)
             {
                 return TypedResults.NotFound();
@@ -56,7 +62,7 @@ public static class SessionEndpoints
         }).RequireAuthorization(nameof(Roles.Instructor)).WithRequestValidation<CreateSessionDto>();
         
         // Join session
-        sessionV1Group.MapPost("/{id:int}/participants", async Task<Results<Ok<JoinSessionResponseDto>, BadRequest<ValidationProblemDetails>>> ([FromBody] JoinSessionDto dto, int id, ISessionService service) =>
+        sessionV1Group.MapPost("/{id:int}/participants", async Task<Results<Ok<JoinSessionResponseDto>, BadRequest<ValidationProblemDetails>>> ([FromBody] JoinSessionDto dto, int id, ISessionService service, ClaimsPrincipal principal) =>
         {
             var result = await service.JoinSessionAnonUser(dto, id);
             if (result.IsFailed)

--- a/API/Endpoints/UserEndpoints.cs
+++ b/API/Endpoints/UserEndpoints.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using Asp.Versioning;
 using Asp.Versioning.Builder;
+using Core.Shared;
 using FluentResults;
 using Infrastructure.Authentication.Contracts;
 using Infrastructure.Authentication.Models;

--- a/Core/Contracts/Repositories/IExerciseRepository.cs
+++ b/Core/Contracts/Repositories/IExerciseRepository.cs
@@ -11,4 +11,5 @@ namespace Core.Contracts.Repositories;
 public interface IExerciseRepository
 {
     Task<Result> InsertExerciseAsync(ExerciseDto dto, int userId);
+    Task<bool> VerifyExerciseIdsAsync(List<int> exerciseIds, int authorId);
 }

--- a/Core/Sessions/Contracts/ISessionRepository.cs
+++ b/Core/Sessions/Contracts/ISessionRepository.cs
@@ -6,6 +6,7 @@ public interface ISessionRepository
 {
     Task<int> InsertSessionAsync(Session session);
     Task<bool> CheckSessionCodeIsValid(string sessionCode, int sessionId);
+    Task<bool> VerifyAuthor(int userId, int sessionId);
     Task<int> CreateAnonUser(int sessionId);
     Task<Session?> GetSessionByIdAsync(int sessionId);
     Task<bool> VerifyParticipantAccess(int userId, int sessionId);

--- a/Core/Sessions/Contracts/ISessionService.cs
+++ b/Core/Sessions/Contracts/ISessionService.cs
@@ -1,4 +1,5 @@
 using Core.Sessions.Models;
+using Core.Shared;
 using FluentResults;
 
 namespace Core.Sessions.Contracts;
@@ -7,5 +8,5 @@ public interface ISessionService
 {
     Task<Result<CreateSessionResponseDto>> CreateSessionAsync(CreateSessionDto sessionDto, int authorId);
     Task<Result<JoinSessionResponseDto>> JoinSessionAnonUser(JoinSessionDto dto, int sessionId);
-    Task<Result<GetSessionResponseDto>> GetSessionByIdAsync(int sessionId, int userId);
+    Task<Result<GetSessionResponseDto>> GetSessionByIdAsync(int sessionId, int userId, Roles role);
 }

--- a/Core/Shared/Roles.cs
+++ b/Core/Shared/Roles.cs
@@ -1,4 +1,4 @@
-namespace Infrastructure.Authentication.Models;
+namespace Core.Shared;
 
 public enum Roles
 {

--- a/Infrastructure/Authentication/Contracts/ITokenService.cs
+++ b/Infrastructure/Authentication/Contracts/ITokenService.cs
@@ -1,3 +1,4 @@
+using Core.Shared;
 using Core.Shared.Contracts;
 using FluentResults;
 using Infrastructure.Authentication.Models;

--- a/Infrastructure/Authentication/Contracts/IUserRepository.cs
+++ b/Infrastructure/Authentication/Contracts/IUserRepository.cs
@@ -1,3 +1,4 @@
+using Core.Shared;
 using Core.Shared.Contracts;
 using FluentResults;
 using Infrastructure.Authentication.Models;

--- a/Infrastructure/Authentication/TokenService.cs
+++ b/Infrastructure/Authentication/TokenService.cs
@@ -2,6 +2,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
+using Core.Shared;
 using FluentResults;
 using Infrastructure.Authentication.Contracts;
 using Infrastructure.Authentication.Exceptions;

--- a/Infrastructure/Authentication/UserRepository.cs
+++ b/Infrastructure/Authentication/UserRepository.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using Core.Shared;
 using Dapper;
 using FluentResults;
 using Infrastructure.Authentication.Contracts;

--- a/Infrastructure/Authentication/UserService.cs
+++ b/Infrastructure/Authentication/UserService.cs
@@ -1,3 +1,4 @@
+using Core.Shared;
 using FluentResults;
 using Infrastructure.Authentication.Contracts;
 using Infrastructure.Authentication.Models;

--- a/Infrastructure/ExerciseRepository.cs
+++ b/Infrastructure/ExerciseRepository.cs
@@ -2,15 +2,7 @@
 using Dapper;
 using FluentResults;
 using Infrastructure.Persistence.Contracts;
-using Microsoft.EntityFrameworkCore.ValueGeneration.Internal;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Transactions;
 using Core.Exercises.Models;
 
 namespace Infrastructure
@@ -26,6 +18,15 @@ namespace Infrastructure
             _logger = logger;
         }
 
+        public async Task<bool> VerifyExerciseIdsAsync(List<int> exerciseIds, int authorId)
+        {
+            using var con = await _connection.CreateConnectionAsync();
+            var query = """
+                        SELECT COUNT(*) FROM EXERCISE WHERE exercise_id = ANY(@Ids) AND author_id = @AuthorId;
+                        """;
+            var result = await con.QuerySingleAsync<int>(query, new { Ids = exerciseIds.ToArray(), @AuthorID = authorId });
+            return exerciseIds.Count == result;
+        }
 
         public async Task<Result> InsertExerciseAsync(ExerciseDto dto, int userId)
         {

--- a/Infrastructure/SessionRepository.cs
+++ b/Infrastructure/SessionRepository.cs
@@ -103,6 +103,19 @@ public class SessionRepository : ISessionRepository
         var result = await con.ExecuteScalarAsync<int>(query, new { UserId = userId, SessionId = sessionId });
         return result == 1;
     }
+
+    public async Task<bool> VerifyAuthor(int userId, int sessionId)
+    {
+        using var con = await _connection.CreateConnectionAsync();
+        var query = """
+                    SELECT COUNT(*) FROM app_users
+                    JOIN session
+                    ON session.author_id = app_users.user_id
+                    WHERE app_users.user_id = @UserId AND session.session_id = @SessionId;
+                    """;
+        var result = await con.QuerySingleAsync<int>(query, new { UserId = userId, SessionId = sessionId });
+        return result == 1;
+    }
     
     public async Task<Session?> GetSessionByIdAsync(int sessionId)
     {

--- a/UnitTest/Core/Session/SessionServiceTest.cs
+++ b/UnitTest/Core/Session/SessionServiceTest.cs
@@ -1,3 +1,4 @@
+using Core.Contracts.Repositories;
 using Core.Sessions;
 using Core.Sessions.Contracts;
 using Core.Shared.Contracts;
@@ -15,7 +16,8 @@ public class SessionServiceTest
         var loggerSub = Substitute.For<ILogger<SessionService>>();
         var sessionRepoSub = Substitute.For<ISessionRepository>();
         var tokenRepoSub = Substitute.For<IAnonTokenService>();
-        var sessionService = new SessionService(sessionRepoSub, loggerSub, tokenRepoSub);
+        var exerciseRepoSub = Substitute.For<IExerciseRepository>();
+        var sessionService = new SessionService(sessionRepoSub, loggerSub, tokenRepoSub, exerciseRepoSub);
         
         // Act
         var result = sessionService.GenerateSessionCode();

--- a/UnitTest/Infrastructure/Authentication/TokenServiceTest.cs
+++ b/UnitTest/Infrastructure/Authentication/TokenServiceTest.cs
@@ -1,5 +1,6 @@
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using Core.Shared;
 using Infrastructure.Authentication;
 using Infrastructure.Authentication.Contracts;
 using Infrastructure.Authentication.Exceptions;


### PR DESCRIPTION
## Description

When creating a session the instructor could not access the session himself, this should be possible. If a session was created the ids of exercise was not validated this has been added. 

### Resolved Issue
Fixes #48 

## Changes

Changes was made to the exercise repo, and the session service. The roles from the infrastructure have been moved to shared Core, we can discussion whether or not this is smart, the functionality can work without doing this.


## Checklist

- [ ] New and old tests passed
