### PR TITLE
feature/50+52

### DIFF
--- a/API/Endpoints/ExerciseEndpoints.cs
+++ b/API/Endpoints/ExerciseEndpoints.cs
@@ -5,7 +5,9 @@ using Asp.Versioning.Builder;
 using Core.Contracts.Repositories;
 using Core.Contracts.Services;
 using Core.Exercises.Models;
+using FluentResults;
 using Infrastructure.Authentication.Models;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
 namespace API.Endpoints;
@@ -21,14 +23,20 @@ public static class ExerciseEndpoints
 
         var exerciseV1 = app.MapGroup("v{version:apiVersion}/exercises").WithApiVersionSet(apiVersionSet).WithTags("Exercise");
 
-        exerciseV1.MapPost("/", async ([FromBody]ExerciseDto dto, ISolutionRunnerService solutionRunner, ClaimsPrincipal principal, IExerciseRepository exerciseRepo) =>
+        exerciseV1.MapPost("/", async Task<Results<Created, Ok<Result>>>([FromBody]ExerciseDto dto, ISolutionRunnerService solutionRunner, ClaimsPrincipal principal, IExerciseRepository exerciseRepo) =>
         {
-            await solutionRunner.SubmitSolutionAsync(dto);
+            var result = await solutionRunner.SubmitSolutionAsync(new ExerciseSubmissionDto(dto.Solution, dto.InputParameterType, dto.OutputParamaterType, dto.Testcases));
+
+            if (result.IsFailed)
+            {
+
+                return TypedResults.Ok(result);
+            }
 
             var userId = principal.Claims.First(c => c.Type == ClaimTypes.UserData).Value;
             await exerciseRepo.InsertExerciseAsync(dto, Convert.ToInt32(userId));
+            return TypedResults.Created();
 
-            TypedResults.Ok(dto);
         }).RequireAuthorization(nameof(Roles.Instructor)).WithRequestValidation<ExerciseDto>();
         
         

--- a/Core/Contracts/Services/ISolutionRunnerService.cs
+++ b/Core/Contracts/Services/ISolutionRunnerService.cs
@@ -4,11 +4,12 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Core.Exercises.Models;
+using FluentResults;
 
 namespace Core.Contracts.Services;
 
 public interface ISolutionRunnerService
 {
-    Task SubmitSolutionAsync(ExerciseDto dto);
+    Task<Result> SubmitSolutionAsync(ExerciseSubmissionDto dto);
 
 }

--- a/Core/Exercises/Models/ExerciseDto.cs
+++ b/Core/Exercises/Models/ExerciseDto.cs
@@ -1,12 +1,12 @@
-﻿namespace Core.Exercises.Models
-{
-    public record ExerciseDto(
-        string Name,
-        string Description,
-        string Solution,
-        string[] InputParameterType,
-        string[] OutputParamaterType,
-        List<Testcase> Testcases);
+﻿using Core.Sessions.Models;
 
-    public record Testcase(string[] inputParams, string[] outputParams);
-}
+namespace Core.Exercises.Models;
+
+public record ExerciseDto(
+    string Name,
+    string Description,
+    string Solution,
+    string[] InputParameterType,
+    string[] OutputParamaterType,
+    List<Testcase> Testcases
+);

--- a/Core/Exercises/Models/ExerciseSubmissionDto.cs
+++ b/Core/Exercises/Models/ExerciseSubmissionDto.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Core.Exercises.Models;
+
+public record ExerciseSubmissionDto (
+    string Solution,
+    string[] InputParameterType,
+    string[] OutputParamaterType,
+    List<Testcase> Testcases);

--- a/Core/Exercises/Models/Testcase.cs
+++ b/Core/Exercises/Models/Testcase.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Core.Exercises.Models;
+
+public record Testcase(string[] InputParams, string[] OutputParams);

--- a/Core/Exercises/Validators/ExerciseDtoValidator.cs
+++ b/Core/Exercises/Validators/ExerciseDtoValidator.cs
@@ -56,12 +56,12 @@ public class ExerciseDtoValidator : AbstractValidator<ExerciseDto>
     {
         foreach (var testcase in testcases)
         {
-            if (testcase.inputParams == null || testcase.inputParams.Length == 0)
+            if (testcase.InputParams == null || testcase.InputParams.Length == 0)
             {
                 _logger.LogInformation("Empty input paramter for; {}", testcase);
                 return false;
             }
-            if (testcase.outputParams == null || testcase.outputParams.Length == 0)
+            if (testcase.OutputParams == null || testcase.OutputParams.Length == 0)
             {
                 _logger.LogInformation("Empty output paramter for; {}", testcase);
                 return false;
@@ -75,11 +75,11 @@ public class ExerciseDtoValidator : AbstractValidator<ExerciseDto>
         try
         {
             var temp = testcases.First();
-            var inputParams = temp.inputParams.Length;
-            var outputParams = temp.outputParams.Length;
+            var inputParams = temp.InputParams.Length;
+            var outputParams = temp.OutputParams.Length;
             foreach (var testcase in testcases)
             {
-                if (testcase.inputParams.Length != inputParams || testcase.outputParams.Length != outputParams)
+                if (testcase.InputParams.Length != inputParams || testcase.OutputParams.Length != outputParams)
                 {
                     _logger.LogInformation("Inconsistency in parameter amount across test cases");
                     return false;
@@ -104,11 +104,11 @@ public class ExerciseDtoValidator : AbstractValidator<ExerciseDto>
                 {
                     switch (dto.InputParameterType[i].ToLower())
                     {
-                        case "bool": var tempInBool = bool.Parse(testcase.inputParams[i]); break;
-                        case "int": var tempInInt = int.Parse(testcase.inputParams[i]); break;
-                        case "float": var tempInFloat = float.Parse(testcase.inputParams[i]); break;
+                        case "bool": var tempInBool = bool.Parse(testcase.InputParams[i]); break;
+                        case "int": var tempInInt = int.Parse(testcase.InputParams[i]); break;
+                        case "float": var tempInFloat = float.Parse(testcase.InputParams[i]); break;
                         case "string": break;
-                        case "char": if (testcase.inputParams[i].Length != 1) { _logger.LogInformation("Empty input param for testcase");  return false; }; break;
+                        case "char": if (testcase.InputParams[i].Length != 1) { _logger.LogInformation("Empty input param for testcase");  return false; }; break;
                         default: _logger.LogInformation("Invalid input"); return false;
                     }
                 }
@@ -116,11 +116,11 @@ public class ExerciseDtoValidator : AbstractValidator<ExerciseDto>
                 {
                     switch (dto.OutputParamaterType[i].ToLower())
                     {
-                        case "bool": var tempOutBool = bool.Parse(testcase.outputParams[i]); break;
-                        case "int": var tempOutInt = int.Parse(testcase.outputParams[i]); break;
-                        case "float": var tempOutFloat = float.Parse(testcase.outputParams[i]); break;
+                        case "bool": var tempOutBool = bool.Parse(testcase.OutputParams[i]); break;
+                        case "int": var tempOutInt = int.Parse(testcase.OutputParams[i]); break;
+                        case "float": var tempOutFloat = float.Parse(testcase.OutputParams[i]); break;
                         case "string": break;
-                        case "char": if (testcase.outputParams[i].Length != 1) { _logger.LogInformation("Empty output param for testcase"); return false; }; break;
+                        case "char": if (testcase.OutputParams[i].Length != 1) { _logger.LogInformation("Empty output param for testcase"); return false; }; break;
                         default: _logger.LogInformation("Invalid output"); return false;
                     }
                 }

--- a/Core/Solutions/Models/Submission.cs
+++ b/Core/Solutions/Models/Submission.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json.Serialization;
+using Core.Exercises.Models;
 
-namespace Core.Exercises.Models
+namespace Core.Solutions.Models
 {
     public record Submission
     {
@@ -10,24 +11,24 @@ namespace Core.Exercises.Models
         [JsonPropertyName("testCases")]
         public List<TestCase> TestCases { get; }
 
-        public Submission(ExerciseDto exerciseDto)
+        public Submission(ExerciseSubmissionDto dto)
         {
-            Solution = exerciseDto.Solution;
+            Solution = dto.Solution;
             TestCases = new List<TestCase>();
 
             int i = 0;
-            foreach (var testCase in exerciseDto.Testcases)
+            foreach (var testCase in dto.Testcases)
             {
                 var inputParams = new List<Parameter>();
-                for(int j = 0; j < testCase.inputParams.Length; j++)
+                for (int j = 0; j < testCase.InputParams.Length; j++)
                 {
-                    inputParams.Add(new Parameter(exerciseDto.InputParameterType[j], testCase.inputParams[j]));
+                    inputParams.Add(new Parameter(dto.InputParameterType[j], testCase.InputParams[j]));
                 }
 
                 var outputParams = new List<Parameter>();
-                for (int j = 0; j < testCase.outputParams.Length; j++)
+                for (int j = 0; j < testCase.OutputParams.Length; j++)
                 {
-                    outputParams.Add(new Parameter(exerciseDto.OutputParamaterType[j], testCase.outputParams[j]));
+                    outputParams.Add(new Parameter(dto.OutputParamaterType[j], testCase.OutputParams[j]));
                 }
 
                 TestCases.Add(new TestCase(i, inputParams, outputParams));

--- a/Infrastructure/ExerciseRepository.cs
+++ b/Infrastructure/ExerciseRepository.cs
@@ -120,10 +120,10 @@ namespace Infrastructure
             string[] paramsDecider;
             if (IsOutput)
             {
-                paramsDecider = tc.outputParams;
+                paramsDecider = tc.OutputParams;
             } else
             {
-                paramsDecider = tc.inputParams;
+                paramsDecider = tc.InputParams;
             }
             for (int j = 0; j<paramType.Length; j++)
             {


### PR DESCRIPTION
## Description
Implements such that Submission now is created from a more generalized class, allowing it to be used for later use cases.
Also handles different responses from the solution runner.

### Resolved Issue
Fixes #50, #52, #55 

## Changes
- Adds new ExerciseSubmissionDto
- Adds response handling from solution runner
- Responds to frontend in case of failed execution on solution runner
  - Here nothing is inserted to the database (have not been confirmed tbh)
- Inserts if execution is accepted, and testcases pass on solution runner.

## Additional Information
The responses received from the solution runner, and provided to the frontend are not in a reader-friendly state, as it has been plucked from a terminal, and are filled with special characters such as `\n` - arguably should be looked at, at a later stage, but for now the functionality is there, albeit with poor messages.

## Checklist

- [ ] I have added test cases for my additions
- [X] New and old tests passed
- [ ] Documentation is updated
