### PR TITLE
Integrationtest exercise

### DIFF
--- a/API/Endpoints/ExerciseEndpoints.cs
+++ b/API/Endpoints/ExerciseEndpoints.cs
@@ -44,20 +44,20 @@ public static class ExerciseEndpoints
         }).RequireAuthorization(nameof(Roles.Instructor)).WithRequestValidation<ExerciseDto>();
         
         exerciseV1.MapGet("/", async Task<Results<Ok<List<GetExercisesResponseDto>>, BadRequest, NotFound>> (ClaimsPrincipal principal, IExerciseService exerciseService) => 
+        {
+            var userId = principal.FindFirst(ClaimTypes.UserData)?.Value;
+            if (userId == null)
             {
-                var userId = principal.FindFirst(ClaimTypes.UserData)?.Value;
-                if (userId == null)
-                {
-                    return TypedResults.BadRequest();
-                }
+                return TypedResults.BadRequest();
+            }
 
-                var results = await exerciseService.GetExercises(Convert.ToInt32(userId));
-                if (results.IsFailed)
-                {
-                    return TypedResults.NotFound();
-                }
-                return TypedResults.Ok(results.Value);
-            }).RequireAuthorization(nameof(Roles.Instructor));
+            var results = await exerciseService.GetExercises(Convert.ToInt32(userId));
+            if (results.IsFailed)
+            {
+                return TypedResults.NotFound();
+            }
+            return TypedResults.Ok(results.Value);
+        }).RequireAuthorization(nameof(Roles.Instructor));
 
         exerciseV1.MapGet("/{exerciseId:int}", async Task<Results<Ok<GetExerciseResponseDto>, BadRequest>> (int exerciseId, IExerciseService exerciseService) =>
         {
@@ -94,20 +94,20 @@ public static class ExerciseEndpoints
         }).RequireAuthorization(nameof(Roles.Instructor)).WithRequestValidation<ExerciseDto>();
 
         exerciseV1.MapDelete("/{exerciseId:int}", async Task<Results<NoContent, NotFound>> (ClaimsPrincipal principal, int exerciseId, IExerciseService exerciseService) =>
+        {
+            var userId = principal.FindFirst(ClaimTypes.UserData)?.Value;
+            if (userId == null)
             {
-                var userId = principal.FindFirst(ClaimTypes.UserData)?.Value;
-                if (userId == null)
-                {
-                    return TypedResults.NotFound();
-                }
+                return TypedResults.NotFound();
+            }
 
-                var results = await exerciseService.DeleteExercise(exerciseId, Convert.ToInt32(userId));
-                if (results.IsFailed)
-                {
-                    return TypedResults.NotFound();
-                }
-                return TypedResults.NoContent();
-            }).RequireAuthorization(nameof(Roles.Instructor));
+            var results = await exerciseService.DeleteExercise(exerciseId, Convert.ToInt32(userId));
+            if (results.IsFailed)
+            {
+                return TypedResults.NotFound();
+            }
+            return TypedResults.NoContent();
+        }).RequireAuthorization(nameof(Roles.Instructor));
         
         exerciseV1.MapPost("/{exerciseId:int}/submission", async Task<IResult> ([FromBody] SubmitSolutionDto dto, int exerciseId, ISolutionRunnerService service, ClaimsPrincipal principal) =>
         {

--- a/API/Endpoints/SessionEndpoints.cs
+++ b/API/Endpoints/SessionEndpoints.cs
@@ -24,13 +24,13 @@ public static class SessionEndpoints
             .WithTags("Sessions");
 
         sessionV1Group.MapDelete("/{sessionId:int}",
-            async Task<Results<NoContent, NotFound>> (ClaimsPrincipal principal, int sessionId,
+            async Task<Results<NoContent, NotFound, BadRequest>> (ClaimsPrincipal principal, int sessionId,
                 ISessionService service) =>
             {
                 var userId = principal.FindFirst( ClaimTypes.UserData)?.Value;
                 if (userId == null)
                 {
-                    return TypedResults.NotFound();
+                    return TypedResults.BadRequest();
                 }
                 
                 var results = await service.DeleteSession(sessionId, Convert.ToInt32(userId));

--- a/API/Program.cs
+++ b/API/Program.cs
@@ -1,6 +1,7 @@
 using API.Configuration;
 using API.Endpoints;
 using Core;
+using Core.Solutions.Models;
 using Core.Solutions.Services;
 using Infrastructure;
 using Infrastructure.Persistence;
@@ -19,7 +20,7 @@ public class Program
         });
         
         // Supported languages
-        builder.Services.AddHttpClient<HaskellService>()
+        builder.Services.AddHttpClient<IHaskellService, HaskellService>()
             .SetHandlerLifetime(TimeSpan.FromSeconds(30));
         
         // Add services to the container.

--- a/Core/Exercises/ExerciseService.cs
+++ b/Core/Exercises/ExerciseService.cs
@@ -81,13 +81,12 @@ public class ExerciseService : IExerciseService
             return Result.Fail("Exercise not updated");
         }
         
-        // Should without a doubt be refactored at some point
         var submissionResult = await _haskellService.SubmitSubmission(new SubmissionDto(dto));
 
         if (submissionResult.IsFailed) 
         {
             _logger.LogInformation("Failed to validate exercise: {exercise}", dto);
-            return Result.Fail("Solution of the exercise did not pass the testcases");
+            return Result.Fail("Internal error occurred on solution runner");
         }
 
         if (!submissionResult.Value.Action.Equals(ResponseCode.Pass))

--- a/Core/Exercises/ExerciseService.cs
+++ b/Core/Exercises/ExerciseService.cs
@@ -13,10 +13,10 @@ public class ExerciseService : IExerciseService
     private readonly IExerciseRepository _exerciseRepository;
     private readonly ILogger<ExerciseService> _logger;
     private readonly ISolutionRepository _solutionRepository;
-    private readonly HaskellService _haskellService;
+    private readonly IHaskellService _haskellService;
 
 
-    public ExerciseService(IExerciseRepository exerciseRepository, ILogger<ExerciseService> logger, ISolutionRepository solutionRepository, HaskellService haskellService)
+    public ExerciseService(IExerciseRepository exerciseRepository, ILogger<ExerciseService> logger, ISolutionRepository solutionRepository, IHaskellService haskellService)
     {
         _exerciseRepository = exerciseRepository;
         _logger = logger;

--- a/Core/Exercises/Models/Testcase.cs
+++ b/Core/Exercises/Models/Testcase.cs
@@ -3,13 +3,10 @@ namespace Core.Exercises.Models;
 public class Testcase
 {
 	public int TestCaseId { get; set; }
-
 	public int ExerciseId { get; set; }
-
 	public int TestCaseNumber { get; set; }
 	public bool IsPublicVisible { get; set; }
 	public List<TestParameter> Input { get; set; } = new();
-
 	public List<TestParameter> Output { get; set; } = new();
 }
 

--- a/Core/Sessions/Contracts/ISessionRepository.cs
+++ b/Core/Sessions/Contracts/ISessionRepository.cs
@@ -1,4 +1,5 @@
 using Core.Sessions.Models;
+using FluentResults;
 
 namespace Core.Sessions.Contracts;
 
@@ -10,7 +11,7 @@ public interface ISessionRepository
     Task<Session?> GetSessionByIdAsync(int sessionId);
     Task<bool> VerifyParticipantAccess(int userId, int sessionId);
     Task DeleteExpiredSessions();
-    Task<Session?> GetSessionBySessionCodeAsync(string sessionCode);
+    Task<Result<Session>> GetSessionBySessionCodeAsync(string sessionCode);
     Task<Session?> GetSessionOverviewAsync(int sessionId, int userId);
     Task<IEnumerable<Session>?> GetSessionsAsync(int authorId);
     Task<bool> DeleteSessionAsync(int sessionId, int authorId);

--- a/Core/Sessions/Contracts/ISessionRepository.cs
+++ b/Core/Sessions/Contracts/ISessionRepository.cs
@@ -10,13 +10,8 @@ public interface ISessionRepository
     Task<Session?> GetSessionByIdAsync(int sessionId);
     Task<bool> VerifyParticipantAccess(int userId, int sessionId);
     Task DeleteExpiredSessions();
-
     Task<Session?> GetSessionBySessionCodeAsync(string sessionCode);
-    
-
     Task<Session?> GetSessionOverviewAsync(int sessionId, int userId);
-
     Task<IEnumerable<Session>?> GetSessionsAsync(int authorId);
-    
     Task<bool> DeleteSessionAsync(int sessionId, int authorId);
 }

--- a/Core/Sessions/Models/Session.cs
+++ b/Core/Sessions/Models/Session.cs
@@ -6,21 +6,13 @@ namespace Core.Sessions.Models;
 public class Session
 {
     public int Id { get; set; }
-
     public string Title { get; set; } = string.Empty;
-
     public string? Description { get; set; }
-
     public int AuthorId { get; set; }
-
     public string AuthorName { get; set; } = string.Empty;
-    
     public DateTime ExpirationTimeUtc { get; set; }
-
     public string SessionCode { get; set; } = string.Empty;
-
     public List<int> Exercises { get; set; } = new (); // this needs to be changed when exercises are available
-
     public List<SolvedExercise> ExerciseDetails { get; set; } = new();
 }
 

--- a/Core/Sessions/SessionService.cs
+++ b/Core/Sessions/SessionService.cs
@@ -69,7 +69,7 @@ public class SessionService : ISessionService
                 _logger.LogInformation("Failed to create session for {userid}", authorId);
                 return Result.Fail("Error creating session");
             }
-            _logger.LogInformation("Succesfully created a unique a unqiue session code: {sessionCode}", sessionCode);
+            _logger.LogInformation("Succesfully created a unique session code: {sessionCode}", sessionCode);
         } else if (sessionId == (int)ErrorCodes.ExerciseDoesNotExist)
         {
             return Result.Fail("Exercises for Author could not be found");
@@ -82,13 +82,13 @@ public class SessionService : ISessionService
     {
         // create anon user entry in table
         var session = await _sessionRepository.GetSessionBySessionCodeAsync(dto.SessionCode);
-        if (session == null)
+        if (session.IsFailed)
         {
             return Result.Fail("Invalid session");
         }
-        var student = await _sessionRepository.CreateAnonUser(session.Id);
+        var student = await _sessionRepository.CreateAnonUser(session.Value.Id);
         
-        var timeOffset = session.ExpirationTimeUtc - DateTime.UtcNow;
+        var timeOffset = session.Value.ExpirationTimeUtc - DateTime.UtcNow;
         
         var createToken = _tokenService.GenerateAnonymousUserJwt((int)Math.Ceiling(timeOffset.TotalMinutes), student);
         return new JoinSessionResponseDto(createToken, DateTime.UtcNow.AddMinutes((int)Math.Ceiling(timeOffset.TotalMinutes)));

--- a/Core/Solutions/Contracts/ISolutionRepository.cs
+++ b/Core/Solutions/Contracts/ISolutionRepository.cs
@@ -5,6 +5,6 @@ namespace Core.Solutions.Contracts;
 public interface ISolutionRepository
 {
 	Task<List<Testcase>?> GetTestCasesByExerciseIdAsync(int exerciseId);
-	Task<bool> CheckAnonUserExistsInSessionAsync(int userId);
+	Task<bool> CheckAnonUserExistsInSessionAsync(int userId, int sessionId);
 	Task<bool> InsertSolvedRelation(int userId, int exerciseId);
 }

--- a/Core/Solutions/Models/IHaskellService.cs
+++ b/Core/Solutions/Models/IHaskellService.cs
@@ -1,0 +1,13 @@
+﻿using FluentResults;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Core.Solutions.Models;
+
+public interface IHaskellService
+{
+    Task<Result<SolutionRunnerResponse>> SubmitSubmission(SubmissionDto submission);
+}

--- a/Core/Solutions/Models/SubmissionDto.cs
+++ b/Core/Solutions/Models/SubmissionDto.cs
@@ -8,9 +8,9 @@ public record SubmissionDto
     public string Solution { get; }
 
     [JsonPropertyName("testCases")]
-    public List<TestCase> TestCases { get; }
+    public List<SubmissionTestCase> TestCases { get; }
 
-    public SubmissionDto(string solution, List<TestCase> testCases)
+    public SubmissionDto(string solution, List<SubmissionTestCase> testCases)
     {
         Solution = solution;
         TestCases = testCases;
@@ -18,7 +18,7 @@ public record SubmissionDto
     public SubmissionDto(ExerciseDto dto)
     {
         Solution = dto.Solution;
-        TestCases = new List<TestCase>();
+        TestCases = new List<SubmissionTestCase>();
 
         int i = 0;
         foreach (var testCase in dto.Testcases)
@@ -35,7 +35,7 @@ public record SubmissionDto
                 outputParams.Add(new Parameter(dto.OutputParamaterType[j], testCase.OutputParams[j]));
             }
 
-            TestCases.Add(new TestCase(i, inputParams, outputParams));
+            TestCases.Add(new SubmissionTestCase(i, inputParams, outputParams));
             i++;
         }
     }
@@ -44,7 +44,7 @@ public record SubmissionDto
 public static class SubmissionMapper {
     public static SubmissionDto ToSubmission(List<Testcase> testCases, string solution)
     {
-        var testDtos = testCases.Select(x => new TestCase(x.TestCaseId, 
+        var testDtos = testCases.Select(x => new SubmissionTestCase(x.TestCaseId, 
             x.Input.Select(y => new Parameter(y.ParameterType, y.ParameterValue)).ToList(),
             x.Output.Select(y => new Parameter(y.ParameterType, y.ParameterValue)).ToList()
             )).ToList();
@@ -52,7 +52,7 @@ public static class SubmissionMapper {
     }
 }
 
-public record TestCase
+public record SubmissionTestCase
 {
     [JsonPropertyName("id")]
     public int Id { get; init; }
@@ -63,7 +63,7 @@ public record TestCase
     [JsonPropertyName("outputParameters")]
     public List<Parameter> OutputParameters { get; }
 
-    public TestCase(int id, List<Parameter> inputParameters, List<Parameter> outputParameters)
+    public SubmissionTestCase(int id, List<Parameter> inputParameters, List<Parameter> outputParameters)
     {
         Id = id;
         InputParameters = inputParameters;

--- a/Core/Solutions/Services/HaskellService.cs
+++ b/Core/Solutions/Services/HaskellService.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Core.Solutions.Services;
 
-public class HaskellService
+public class HaskellService : IHaskellService
 {
     private readonly HttpClient _httpClient;
     private readonly ILogger<HaskellService> _logger;

--- a/Core/Solutions/SolutionRunnnerService.cs
+++ b/Core/Solutions/SolutionRunnnerService.cs
@@ -9,10 +9,10 @@ namespace Core.Solutions;
 public class SolutionRunnnerService : ISolutionRunnerService
 {
     private readonly ILogger<SolutionRunnnerService> _logger;
-    private readonly HaskellService _haskellService;
+    private readonly IHaskellService _haskellService;
     private readonly ISolutionRepository _solutionRepository;
 
-    public SolutionRunnnerService(ILogger<SolutionRunnnerService> logger, HaskellService haskellService, ISolutionRepository solutionRepository)
+    public SolutionRunnnerService(ILogger<SolutionRunnnerService> logger, IHaskellService haskellService, ISolutionRepository solutionRepository)
     {
         _logger = logger;
         _haskellService = haskellService;

--- a/Core/Solutions/SolutionRunnnerService.cs
+++ b/Core/Solutions/SolutionRunnnerService.cs
@@ -19,21 +19,11 @@ public class SolutionRunnnerService : ISolutionRunnerService
         _solutionRepository = solutionRepository;
     }
 
-    // public async Task<Result<>> ConfirmSolutionAsync(ExerciseDto dto)
-    // {
-    //     var result = await _haskellService.SubmitSubmission(new SubmissionDto(dto));
-    //     if (result.IsFailed)
-    //     {
-    //         return result;
-    //     }
-    //     return await _haskellService.SubmitSubmission(new SubmissionDto(dto));
-    // }
-
     public async Task<Result<HaskellResponseDto>> SubmitSolutionAsync(SubmitSolutionDto dto, int exerciseId, int userId)
     {
         // validate anon user is part of a given session
         // Short circuit if user is not part of the session
-        var userExistsInSession = await _solutionRepository.CheckAnonUserExistsInSessionAsync(userId);
+        var userExistsInSession = await _solutionRepository.CheckAnonUserExistsInSessionAsync(userId, dto.SessionId);
         if (!userExistsInSession)
         {
             _logger.LogWarning("User {UserId} does not exist in Session {SessionId}", userId, dto.SessionId);

--- a/Infrastructure/SessionRepository.cs
+++ b/Infrastructure/SessionRepository.cs
@@ -4,6 +4,7 @@ using Core.Sessions;
 using Core.Sessions.Contracts;
 using Core.Sessions.Models;
 using Dapper;
+using FluentResults;
 using Infrastructure.Authentication.Contracts;
 using Infrastructure.Persistence;
 using Infrastructure.Persistence.Contracts;
@@ -177,7 +178,7 @@ public class SessionRepository : ISessionRepository
     }
 
     
-    public async Task<Session?> GetSessionBySessionCodeAsync(string sessionCode)
+    public async Task<Result<Session>> GetSessionBySessionCodeAsync(string sessionCode)
     {
         var query = """
                     SELECT session_id AS id, title, description, author_id AS authorid, expirationtime_utc AS ExpirationTimeUtc, app_users.name AS authorname  
@@ -189,7 +190,7 @@ public class SessionRepository : ISessionRepository
         var session = await con.QueryFirstOrDefaultAsync<Session>(query, new { sessionCode });
         if (session == null)
         {
-            return null;
+            return Result.Fail("Failed to find session"); 
         }
         
         var exercisesQuery = """
@@ -202,7 +203,7 @@ public class SessionRepository : ISessionRepository
         session.ExerciseDetails = exercises.ToList();
             
         
-        return session;
+        return Result.Ok(session);
     }
     
     public async Task<Session?> GetSessionByIdAsync(int sessionId)

--- a/Infrastructure/SolutionRepository.cs
+++ b/Infrastructure/SolutionRepository.cs
@@ -73,10 +73,7 @@ public class SolutionRepository : ISolutionRepository
 	{
 		using var con = await _dbConnection.CreateConnectionAsync();
 		var query = """
-		            SELECT COUNT(*) FROM exercise_in_session AS eis
-		                JOIN anon_users AS au
-		                ON au.session_id = eis.session_id
-		            WHERE au.user_id = @UserId AND eis.session_id = @SessionId;
+		            SELECT Count(*) FROM anon_users WHERE user_id = @UserID AND session_id = @SessionId
 		            """;
 		var result = await con.ExecuteScalarAsync<int>(query, new { UserId = userId, SessionId = sessionId });
 		return result > 0;

--- a/Infrastructure/SolutionRepository.cs
+++ b/Infrastructure/SolutionRepository.cs
@@ -69,16 +69,16 @@ public class SolutionRepository : ISolutionRepository
 		}
 	}
 
-	public async Task<bool> CheckAnonUserExistsInSessionAsync(int userId)
+	public async Task<bool> CheckAnonUserExistsInSessionAsync(int userId, int sessionId)
 	{
 		using var con = await _dbConnection.CreateConnectionAsync();
 		var query = """
 		            SELECT COUNT(*) FROM exercise_in_session AS eis
 		                JOIN anon_users AS au
 		                ON au.session_id = eis.session_id
-		            WHERE au.user_id = @UserId;
+		            WHERE au.user_id = @UserId AND eis.session_id = @SessionId;
 		            """;
-		var result = await con.ExecuteScalarAsync<int>(query, new { UserId = userId });
+		var result = await con.ExecuteScalarAsync<int>(query, new { UserId = userId, SessionId = sessionId });
 		return result > 0;
 	}
 

--- a/IntegrationTest/ExerciseEndpointsTest.cs
+++ b/IntegrationTest/ExerciseEndpointsTest.cs
@@ -17,6 +17,7 @@ using System.Text;
 
 namespace IntegrationTest;
 
+[Collection(CollectionDefinitions.NonParallelCollectionName)]
 public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Program>>
 {
     private readonly HttpClient _client;
@@ -177,6 +178,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var responseContent = await response.Content.ReadFromJsonAsync<List<GetExercisesResponseDto>>();
+        Assert.IsType<List<GetExercisesResponseDto>>(responseContent);
         Assert.Equal(responseContent!.First(), exerciseRepoResponse.First());
     }
 
@@ -228,6 +230,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var responseContent = await response.Content.ReadFromJsonAsync<GetExerciseResponseDto>();
+        Assert.IsType<GetExerciseResponseDto>(responseContent);
         Assert.Equal(exerciseRepoResponse.Title, responseContent.Title);
         Assert.Equal(solutionRepoResponse.First().Input.First().ParameterValue, responseContent.TestCases.First().InputParams.First());
     }

--- a/IntegrationTest/ExerciseEndpointsTest.cs
+++ b/IntegrationTest/ExerciseEndpointsTest.cs
@@ -46,7 +46,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         _client.AddRoleAuth(userId, roles);
         var requestBody = CreateExerciseRequestBody();
 
-        var response = await _client.PostAsync("/v1/exercises", requestBody);
+        var response = await _client.PostAsJsonAsync("/v1/exercises", requestBody);
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
@@ -67,7 +67,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         _client.AddRoleAuth(userId, roles);
         var requestBody = CreateExerciseRequestBody();
 
-        var response = await _client.PostAsync("/v1/exercises", requestBody);
+        var response = await _client.PostAsJsonAsync("/v1/exercises", requestBody);
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
     }
@@ -88,7 +88,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         _client.AddRoleAuth(userId, roles);
         var requestBody = CreateExerciseRequestBody();
 
-        var response = await _client.PostAsync("/v1/exercises", requestBody);
+        var response = await _client.PostAsJsonAsync("/v1/exercises", requestBody);
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
     }
@@ -113,7 +113,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         _client.AddRoleAuth(userId, roles);
         var requestBody = CreateExerciseRequestBody();
 
-        var response = await _client.PostAsync("/v1/exercises", requestBody);
+        var response = await _client.PostAsJsonAsync("/v1/exercises", requestBody);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -138,7 +138,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         _client.AddRoleAuth(userId, roles);
         var requestBody = CreateExerciseRequestBody();
 
-        var response = await _client.PostAsync("/v1/exercises", requestBody);
+        var response = await _client.PostAsJsonAsync("/v1/exercises", requestBody);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -156,7 +156,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
 
         var requestBody = CreateExerciseRequestBody();
 
-        var response = await _client.PostAsync("/v1/exercises", requestBody);
+        var response = await _client.PostAsJsonAsync("/v1/exercises", requestBody);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -285,13 +285,13 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         _client.AddRoleAuth(userId, roles);
         var requestBody = CreateExerciseRequestBody();
 
-        var response = await _client.PutAsync("v1/exercises/1", requestBody);
+        var response = await _client.PutAsJsonAsync("v1/exercises/1", requestBody);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
     [Fact]
-    public async Task UpdateExercise_RepositoryError_ShouldReturn_400()
+    public async Task UpdateExercise_RepositoryError_ShouldReturn_500()
     {
         using var scope = _factory.Services.CreateScope();
         var haskellServiceSub = scope.ServiceProvider.GetService<IHaskellService>();
@@ -307,7 +307,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         _client.AddRoleAuth(userId, roles);
         var requestBody = CreateExerciseRequestBody();
 
-        var response = await _client.PutAsync("v1/exercises/1", requestBody);
+        var response = await _client.PutAsJsonAsync("v1/exercises/1", requestBody);
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
     }
@@ -333,7 +333,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         _client.AddRoleAuth(userId, roles);
         var requestBody = CreateExerciseRequestBody();
 
-        var response = await _client.PutAsync("v1/exercises/1", requestBody);
+        var response = await _client.PutAsJsonAsync("v1/exercises/1", requestBody);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -359,7 +359,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         _client.AddRoleAuth(userId, roles);
         var requestBody = CreateExerciseRequestBody();
 
-        var response = await _client.PutAsync("v1/exercises/1", requestBody);
+        var response = await _client.PutAsJsonAsync("v1/exercises/1", requestBody);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -378,7 +378,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
 
         var requestBody = CreateExerciseRequestBody();
 
-        var response = await _client.PutAsync("v1/exercises/1", requestBody);
+        var response = await _client.PutAsJsonAsync("v1/exercises/1", requestBody);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -451,13 +451,8 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         var roles = new List<Roles> { Roles.AnonymousUser };
         _client.AddRoleAuth(userId, roles);
         var requestBody = new SubmitSolutionDto(1, "x + y");
-        var jsonBody = new StringContent(
-            System.Text.Json.JsonSerializer.Serialize(requestBody),
-            Encoding.UTF8,
-            "application/json"
-        );
 
-        var response = await _client.PostAsync("/v1/exercises/1/submission", jsonBody);
+        var response = await _client.PostAsJsonAsync("/v1/exercises/1/submission", requestBody);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
@@ -484,13 +479,8 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         var roles = new List<Roles> { Roles.AnonymousUser };
         _client.AddRoleAuth(userId, roles);
         var requestBody = new SubmitSolutionDto(1, "x + y");
-        var jsonBody = new StringContent(
-            System.Text.Json.JsonSerializer.Serialize(requestBody),
-            Encoding.UTF8,
-            "application/json"
-        );
 
-        var response = await _client.PostAsync("/v1/exercises/1/submission", jsonBody);
+        var response = await _client.PostAsJsonAsync("/v1/exercises/1/submission", requestBody);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -513,13 +503,8 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         var roles = new List<Roles> { Roles.AnonymousUser };
         _client.AddRoleAuth(userId, roles);
         var requestBody = new SubmitSolutionDto(1, "x + y");
-        var jsonBody = new StringContent(
-            System.Text.Json.JsonSerializer.Serialize(requestBody),
-            Encoding.UTF8,
-            "application/json"
-        );
 
-        var response = await _client.PostAsync("/v1/exercises/1/submission", jsonBody);
+        var response = await _client.PostAsJsonAsync("/v1/exercises/1/submission", requestBody);
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
     }
@@ -539,20 +524,15 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         solutionRepoSub.InsertSolvedRelation(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
 
         var requestBody = new SubmitSolutionDto(1, "x + y");
-        var jsonBody = new StringContent(
-            System.Text.Json.JsonSerializer.Serialize(requestBody),
-            Encoding.UTF8,
-            "application/json"
-        );
 
-        var response = await _client.PostAsync("/v1/exercises/1/submission", jsonBody);
+        var response = await _client.PostAsJsonAsync("/v1/exercises/1/submission", requestBody);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 
-    private StringContent CreateExerciseRequestBody()
+    private object CreateExerciseRequestBody()
     {
-        var requestBody = new
+        return new
         {
             Name = "Sum of Two Numbers",
             Description = "A function that calculates the sum of two integers.",
@@ -565,12 +545,6 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
                 new { InputParams = new[] { "-1" }, OutputParams = new[] { "1" }, PublicVisible = false }
             }
         };
-
-        return new StringContent(
-            System.Text.Json.JsonSerializer.Serialize(requestBody),
-            Encoding.UTF8,
-            "application/json"
-        );
     }
 
 }

--- a/IntegrationTest/ExerciseEndpointsTest.cs
+++ b/IntegrationTest/ExerciseEndpointsTest.cs
@@ -1,0 +1,81 @@
+﻿using API;
+using Core.Exercises.Contracts;
+using Core.Exercises.Models;
+using Core.Sessions.Contracts;
+using Core.Shared;
+using Core.Solutions.Models;
+using Core.Solutions.Services;
+using FluentResults;
+using IntegrationTest.Setup;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace IntegrationTest;
+
+public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+    private readonly TestWebApplicationFactory<Program> _factory;
+    private readonly ILogger<HaskellService> haskellLoggerSub = Substitute.For<ILogger<HaskellService>>();
+
+    public ExerciseEndpointsTest(TestWebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task CreateExercise_ShouldReturn_201()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
+        exerciseRepoSub!.InsertExerciseAsync(Arg.Any<ExerciseDto>(), Arg.Any<int>()).Returns(Result.Ok());
+        var haskellServiceSub = scope.ServiceProvider.GetService<IHaskellService>();
+        haskellServiceSub!.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(new SolutionRunnerResponse { Action = ResponseCode.Pass });
+
+        var userId = 1;
+        var roles = new List<Roles> { Roles.Instructor };
+        _client.AddRoleAuth(userId, roles);
+        var requestBody = new
+        {
+            Name = "Sum of Two Numbers",
+            Description = "A function that calculates the sum of two integers.",
+            Solution = "solution x =\n  if x < 0\n     x * (-1)\n    else x",
+            InputParameterType = new[] { "int", },
+            OutputParamaterType = new[] { "int" },
+            Testcases = new[]
+            {
+                new
+                {
+                    InputParams = new[] { "1", },
+                    OutputParams = new[] { "1" },
+                    PublicVisible = true
+                },
+                new
+                {
+                    InputParams = new[] { "-1", },
+                    OutputParams = new[] { "1" },
+                    PublicVisible = false
+                }
+            }
+        };
+        var jsonBody = new StringContent(
+            System.Text.Json.JsonSerializer.Serialize(requestBody),
+            Encoding.UTF8,
+            "application/json"
+        );
+
+        var response = await _client.PostAsync("/v1/exercises", jsonBody);
+
+        Assert.True(response.StatusCode == HttpStatusCode.Created);
+    }
+
+}

--- a/IntegrationTest/ExerciseEndpointsTest.cs
+++ b/IntegrationTest/ExerciseEndpointsTest.cs
@@ -2,11 +2,14 @@
 using Core.Exercises.Contracts;
 using Core.Exercises.Models;
 using Core.Sessions.Contracts;
+using Core.Sessions.Models;
 using Core.Shared;
+using Core.Solutions.Contracts;
 using Core.Solutions.Models;
 using Core.Solutions.Services;
 using FluentResults;
 using IntegrationTest.Setup;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -14,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Http.Json;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Linq;
@@ -36,37 +40,17 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
     public async Task CreateExercise_ShouldReturn_201()
     {
         using var scope = _factory.Services.CreateScope();
-        var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
-        exerciseRepoSub!.InsertExerciseAsync(Arg.Any<ExerciseDto>(), Arg.Any<int>()).Returns(Result.Ok());
         var haskellServiceSub = scope.ServiceProvider.GetService<IHaskellService>();
+        var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
+
         haskellServiceSub!.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(new SolutionRunnerResponse { Action = ResponseCode.Pass });
+        exerciseRepoSub!.InsertExerciseAsync(Arg.Any<ExerciseDto>(), Arg.Any<int>()).Returns(Result.Ok());
 
         var userId = 1;
         var roles = new List<Roles> { Roles.Instructor };
         _client.AddRoleAuth(userId, roles);
-        var requestBody = new
-        {
-            Name = "Sum of Two Numbers",
-            Description = "A function that calculates the sum of two integers.",
-            Solution = "solution x =\n  if x < 0\n     x * (-1)\n    else x",
-            InputParameterType = new[] { "int", },
-            OutputParamaterType = new[] { "int" },
-            Testcases = new[]
-            {
-                new
-                {
-                    InputParams = new[] { "1", },
-                    OutputParams = new[] { "1" },
-                    PublicVisible = true
-                },
-                new
-                {
-                    InputParams = new[] { "-1", },
-                    OutputParams = new[] { "1" },
-                    PublicVisible = false
-                }
-            }
-        };
+        var requestBody = CreateExerciseRequestBody();
+
         var jsonBody = new StringContent(
             System.Text.Json.JsonSerializer.Serialize(requestBody),
             Encoding.UTF8,
@@ -75,7 +59,229 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
 
         var response = await _client.PostAsync("/v1/exercises", jsonBody);
 
-        Assert.True(response.StatusCode == HttpStatusCode.Created);
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateExercise_InternalErrorAtSolutionRunner_ShouldReturn_500()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var haskellServiceSub = scope.ServiceProvider.GetService<IHaskellService>();
+        var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
+
+        haskellServiceSub!.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(Result.Fail("SolutionRunner sent internal error"));
+        exerciseRepoSub!.InsertExerciseAsync(Arg.Any<ExerciseDto>(), Arg.Any<int>()).Returns(Result.Ok());
+
+        var userId = 1;
+        var roles = new List<Roles> { Roles.Instructor };
+        _client.AddRoleAuth(userId, roles);
+        var requestBody = CreateExerciseRequestBody();
+
+        var jsonBody = new StringContent(
+            System.Text.Json.JsonSerializer.Serialize(requestBody),
+            Encoding.UTF8,
+            "application/json"
+        );
+
+        var response = await _client.PostAsync("/v1/exercises", jsonBody);
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateExercise_FailedToInsertIntoDatabase_ShouldReturn_500()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var haskellServiceSub = scope.ServiceProvider.GetService<IHaskellService>();
+        var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
+
+        haskellServiceSub!.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(new SolutionRunnerResponse { Action = ResponseCode.Pass });
+        exerciseRepoSub!.InsertExerciseAsync(Arg.Any<ExerciseDto>(), Arg.Any<int>()).Returns(Result.Fail("Failed to insert into database"));
+
+        var userId = 1;
+        var roles = new List<Roles> { Roles.Instructor };
+        _client.AddRoleAuth(userId, roles);
+        var requestBody = CreateExerciseRequestBody();
+
+        var jsonBody = new StringContent(
+            System.Text.Json.JsonSerializer.Serialize(requestBody),
+            Encoding.UTF8,
+            "application/json"
+        );
+
+        var response = await _client.PostAsync("/v1/exercises", jsonBody);
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateExercise_SolutionRunnerFailureResponse_ShouldReturn_400()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var haskellServiceSub = scope.ServiceProvider.GetService<IHaskellService>();
+        var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
+
+        var haskellRespnose = new SolutionRunnerResponse
+        {
+            Action = ResponseCode.Failure,
+            ResponseDto = new SolutionResponseDto("failure", null, new List<SolutionTestcaseResultDto> { new SolutionTestcaseResultDto(5, "test", null, null) })
+        };
+        haskellServiceSub!.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(haskellRespnose);
+        exerciseRepoSub!.InsertExerciseAsync(Arg.Any<ExerciseDto>(), Arg.Any<int>()).Returns(Result.Ok());
+
+        var userId = 1;
+        var roles = new List<Roles> { Roles.Instructor };
+        _client.AddRoleAuth(userId, roles);
+        var requestBody = CreateExerciseRequestBody();
+
+        var jsonBody = new StringContent(
+            System.Text.Json.JsonSerializer.Serialize(requestBody),
+            Encoding.UTF8,
+            "application/json"
+        );
+
+        var response = await _client.PostAsync("/v1/exercises", jsonBody);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateExercise_SolutionRunnerErrorResponse_ShouldReturn_400()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var haskellServiceSub = scope.ServiceProvider.GetService<IHaskellService>();
+        var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
+
+        var haskellRespnose = new SolutionRunnerResponse
+        {
+            Action = ResponseCode.Error,
+            ResponseDto = new SolutionResponseDto("error", "compilation error", null)
+        }; 
+        haskellServiceSub!.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(haskellRespnose);
+        exerciseRepoSub!.InsertExerciseAsync(Arg.Any<ExerciseDto>(), Arg.Any<int>()).Returns(Result.Ok());
+
+        var userId = 1;
+        var roles = new List<Roles> { Roles.Instructor };
+        _client.AddRoleAuth(userId, roles);
+        var requestBody = CreateExerciseRequestBody();
+
+        var jsonBody = new StringContent(
+            System.Text.Json.JsonSerializer.Serialize(requestBody),
+            Encoding.UTF8,
+            "application/json"
+        );
+
+        var response = await _client.PostAsync("/v1/exercises", jsonBody);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetExercisesByAuthor_ShouldReturn_GetExercisesResponseDtoList()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
+
+        var exerciseRepoResponse = new List<GetExercisesResponseDto> { new GetExercisesResponseDto(1, "Add numbers")};
+        exerciseRepoSub!.GetExercisesAsync(Arg.Any<int>()).Returns(exerciseRepoResponse);
+
+        var userId = 1;
+        var roles = new List<Roles> { Roles.Instructor };
+        _client.AddRoleAuth(userId, roles);
+
+        var response = await _client.GetAsync("/v1/exercises");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var responseContent = await response.Content.ReadFromJsonAsync<List<GetExercisesResponseDto>>();
+        Assert.Equal(responseContent!.First(), exerciseRepoResponse.First());
+    }
+
+    [Fact]
+    public async Task GetExercisesByAuthor_NoExercisesFound_ShouldReturn_404()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
+
+        var exerciseRepoResponse = new List<GetExercisesResponseDto> { };
+        exerciseRepoSub!.GetExercisesAsync(Arg.Any<int>()).Returns(exerciseRepoResponse);
+
+        var userId = 1;
+        var roles = new List<Roles> { Roles.Instructor };
+        _client.AddRoleAuth(userId, roles);
+
+        var response = await _client.GetAsync("/v1/exercises");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetExerciseById_ShouldReturn_GetExerciseResponseDto()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
+        var solutionRepoSub = scope.ServiceProvider.GetService<ISolutionRepository>();
+        
+        var exerciseRepoResponse = new GetExerciseResponseDto { Id = 1, Title = "Numbers sum"};
+        exerciseRepoSub!.GetExerciseByIdAsync(Arg.Any<int>()).Returns(exerciseRepoResponse);
+        var solutionRepoResponse = new List<Testcase> { new Testcase { TestCaseId = 1,  IsPublicVisible = true, Input = { new TestParameter { ParameterType = "int", ParameterValue = "1" } }, Output = { new TestParameter { ParameterType = "int", ParameterValue = "1" } } } };
+        solutionRepoSub!.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(solutionRepoResponse);
+
+        var response = await _client.GetAsync("/v1/exercises/1");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var responseContent = await response.Content.ReadFromJsonAsync<GetExerciseResponseDto>();
+        Assert.Equal(exerciseRepoResponse.Title, responseContent.Title);
+        Assert.Equal(solutionRepoResponse.First().Input.First().ParameterValue, responseContent.TestCases.First().InputParams.First());
+    }
+
+    [Fact]
+    public async Task GetExerciseById_NoExerciseFound_ShouldReturn_400()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
+        var solutionRepoSub = scope.ServiceProvider.GetService<ISolutionRepository>();
+
+        exerciseRepoSub!.GetExerciseByIdAsync(Arg.Any<int>()).Returns((GetExerciseResponseDto?)null);
+        var solutionRepoResponse = new List<Testcase> { new Testcase { TestCaseId = 1, IsPublicVisible = true, Input = { new TestParameter { ParameterType = "int", ParameterValue = "1" } }, Output = { new TestParameter { ParameterType = "int", ParameterValue = "1" } } } };
+        solutionRepoSub!.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(solutionRepoResponse);
+
+        var response = await _client.GetAsync("/v1/exercises/1");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetExerciseById_FoundNoTestcases_ShouldReturn_400()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
+        var solutionRepoSub = scope.ServiceProvider.GetService<ISolutionRepository>();
+
+        var exerciseRepoResponse = new GetExerciseResponseDto { Id = 1, Title = "Numbers sum" };
+        exerciseRepoSub!.GetExerciseByIdAsync(Arg.Any<int>()).Returns(exerciseRepoResponse);
+        var solutionRepoResponse = new List<Testcase> { };
+        solutionRepoSub!.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(solutionRepoResponse);
+
+        var response = await _client.GetAsync("/v1/exercises/1");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    private object CreateExerciseRequestBody()
+    {
+        return new
+        {
+            Name = "Sum of Two Numbers",
+            Description = "A function that calculates the sum of two integers.",
+            Solution = "solution x =\n  if x < 0\n     x * (-1)\n    else x",
+            InputParameterType = new[] { "int" },
+            OutputParamaterType = new[] { "int" },
+            Testcases = new[]
+            {
+                new { InputParams = new[] { "1" }, OutputParams = new[] { "1" }, PublicVisible = true },
+                new { InputParams = new[] { "-1" }, OutputParams = new[] { "1" }, PublicVisible = false }
+            }
+        };
     }
 
 }

--- a/IntegrationTest/ExerciseEndpointsTest.cs
+++ b/IntegrationTest/ExerciseEndpointsTest.cs
@@ -43,7 +43,8 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         var haskellServiceSub = scope.ServiceProvider.GetService<IHaskellService>();
         var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
 
-        haskellServiceSub!.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(new SolutionRunnerResponse { Action = ResponseCode.Pass });
+        var solutionRunnerResponse = new SolutionRunnerResponse { Action = ResponseCode.Pass };
+        haskellServiceSub!.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(solutionRunnerResponse);
         exerciseRepoSub!.InsertExerciseAsync(Arg.Any<ExerciseDto>(), Arg.Any<int>()).Returns(Result.Ok());
 
         var userId = 1;
@@ -51,13 +52,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         _client.AddRoleAuth(userId, roles);
         var requestBody = CreateExerciseRequestBody();
 
-        var jsonBody = new StringContent(
-            System.Text.Json.JsonSerializer.Serialize(requestBody),
-            Encoding.UTF8,
-            "application/json"
-        );
-
-        var response = await _client.PostAsync("/v1/exercises", jsonBody);
+        var response = await _client.PostAsync("/v1/exercises", requestBody);
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
     }
@@ -69,7 +64,8 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         var haskellServiceSub = scope.ServiceProvider.GetService<IHaskellService>();
         var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
 
-        haskellServiceSub!.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(Result.Fail("SolutionRunner sent internal error"));
+        var solutionRunnerResponse = Result.Fail("SolutionRunner sent internal error");
+        haskellServiceSub!.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(solutionRunnerResponse);
         exerciseRepoSub!.InsertExerciseAsync(Arg.Any<ExerciseDto>(), Arg.Any<int>()).Returns(Result.Ok());
 
         var userId = 1;
@@ -77,13 +73,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         _client.AddRoleAuth(userId, roles);
         var requestBody = CreateExerciseRequestBody();
 
-        var jsonBody = new StringContent(
-            System.Text.Json.JsonSerializer.Serialize(requestBody),
-            Encoding.UTF8,
-            "application/json"
-        );
-
-        var response = await _client.PostAsync("/v1/exercises", jsonBody);
+        var response = await _client.PostAsync("/v1/exercises", requestBody);
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
     }
@@ -95,7 +85,8 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         var haskellServiceSub = scope.ServiceProvider.GetService<IHaskellService>();
         var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
 
-        haskellServiceSub!.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(new SolutionRunnerResponse { Action = ResponseCode.Pass });
+        var solutionRunnerResponse = new SolutionRunnerResponse { Action = ResponseCode.Pass };
+        haskellServiceSub!.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(solutionRunnerResponse);
         exerciseRepoSub!.InsertExerciseAsync(Arg.Any<ExerciseDto>(), Arg.Any<int>()).Returns(Result.Fail("Failed to insert into database"));
 
         var userId = 1;
@@ -103,13 +94,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         _client.AddRoleAuth(userId, roles);
         var requestBody = CreateExerciseRequestBody();
 
-        var jsonBody = new StringContent(
-            System.Text.Json.JsonSerializer.Serialize(requestBody),
-            Encoding.UTF8,
-            "application/json"
-        );
-
-        var response = await _client.PostAsync("/v1/exercises", jsonBody);
+        var response = await _client.PostAsync("/v1/exercises", requestBody);
 
         Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
     }
@@ -121,12 +106,12 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         var haskellServiceSub = scope.ServiceProvider.GetService<IHaskellService>();
         var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
 
-        var haskellRespnose = new SolutionRunnerResponse
+        var solutionRunnerResponse = new SolutionRunnerResponse
         {
             Action = ResponseCode.Failure,
             ResponseDto = new SolutionResponseDto("failure", null, new List<SolutionTestcaseResultDto> { new SolutionTestcaseResultDto(5, "test", null, null) })
         };
-        haskellServiceSub!.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(haskellRespnose);
+        haskellServiceSub!.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(solutionRunnerResponse);
         exerciseRepoSub!.InsertExerciseAsync(Arg.Any<ExerciseDto>(), Arg.Any<int>()).Returns(Result.Ok());
 
         var userId = 1;
@@ -134,13 +119,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         _client.AddRoleAuth(userId, roles);
         var requestBody = CreateExerciseRequestBody();
 
-        var jsonBody = new StringContent(
-            System.Text.Json.JsonSerializer.Serialize(requestBody),
-            Encoding.UTF8,
-            "application/json"
-        );
-
-        var response = await _client.PostAsync("/v1/exercises", jsonBody);
+        var response = await _client.PostAsync("/v1/exercises", requestBody);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -152,12 +131,12 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         var haskellServiceSub = scope.ServiceProvider.GetService<IHaskellService>();
         var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
 
-        var haskellRespnose = new SolutionRunnerResponse
+        var solutionRunnerResponse = new SolutionRunnerResponse
         {
             Action = ResponseCode.Error,
             ResponseDto = new SolutionResponseDto("error", "compilation error", null)
         }; 
-        haskellServiceSub!.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(haskellRespnose);
+        haskellServiceSub!.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(solutionRunnerResponse);
         exerciseRepoSub!.InsertExerciseAsync(Arg.Any<ExerciseDto>(), Arg.Any<int>()).Returns(Result.Ok());
 
         var userId = 1;
@@ -165,13 +144,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         _client.AddRoleAuth(userId, roles);
         var requestBody = CreateExerciseRequestBody();
 
-        var jsonBody = new StringContent(
-            System.Text.Json.JsonSerializer.Serialize(requestBody),
-            Encoding.UTF8,
-            "application/json"
-        );
-
-        var response = await _client.PostAsync("/v1/exercises", jsonBody);
+        var response = await _client.PostAsync("/v1/exercises", requestBody);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -267,9 +240,232 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
-    private object CreateExerciseRequestBody()
+    [Fact]
+    public async Task UpdateExercise_ShouldReturn_200()
     {
-        return new
+        using var scope = _factory.Services.CreateScope();
+        var haskellServiceSub = scope.ServiceProvider.GetService<IHaskellService>();
+        var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
+
+        exerciseRepoSub.VerifyExerciseAuthorAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+        var solutionRunnerResponse = new SolutionRunnerResponse { Action = ResponseCode.Pass };
+        haskellServiceSub.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(solutionRunnerResponse);
+        exerciseRepoSub.UpdateExerciseAsync(Arg.Any<ExerciseDto>(), Arg.Any<int>()).Returns(Result.Ok());
+
+        var userId = 1;
+        var roles = new List<Roles> { Roles.Instructor };
+        _client.AddRoleAuth(userId, roles);
+        var requestBody = CreateExerciseRequestBody();
+
+        var response = await _client.PutAsync("v1/exercises/1", requestBody);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateExercise_RepositoryError_ShouldReturn_400()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var haskellServiceSub = scope.ServiceProvider.GetService<IHaskellService>();
+        var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
+
+        exerciseRepoSub.VerifyExerciseAuthorAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+        var solutionRunnerResponse = new SolutionRunnerResponse { Action = ResponseCode.Pass };
+        haskellServiceSub.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(solutionRunnerResponse);
+        exerciseRepoSub.UpdateExerciseAsync(Arg.Any<ExerciseDto>(), Arg.Any<int>()).Returns(Result.Fail("Update of database failed"));
+
+        var userId = 1;
+        var roles = new List<Roles> { Roles.Instructor };
+        _client.AddRoleAuth(userId, roles);
+        var requestBody = CreateExerciseRequestBody();
+
+        var response = await _client.PutAsync("v1/exercises/1", requestBody);
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateExercise_FailedToValidateSolution_ShouldReturn_400()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var haskellServiceSub = scope.ServiceProvider.GetService<IHaskellService>();
+        var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
+
+        exerciseRepoSub.VerifyExerciseAuthorAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+        var solutionRunnerResponse = new SolutionRunnerResponse
+        {
+            Action = ResponseCode.Failure,
+            ResponseDto = new SolutionResponseDto("failure", null, new List<SolutionTestcaseResultDto> { new SolutionTestcaseResultDto(5, "test", null, null) })
+        };
+        haskellServiceSub.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(solutionRunnerResponse);
+        exerciseRepoSub.UpdateExerciseAsync(Arg.Any<ExerciseDto>(), Arg.Any<int>()).Returns(Result.Ok());
+
+        var userId = 1;
+        var roles = new List<Roles> { Roles.Instructor };
+        _client.AddRoleAuth(userId, roles);
+        var requestBody = CreateExerciseRequestBody();
+
+        var response = await _client.PutAsync("v1/exercises/1", requestBody);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateExercise_CompilationErrorOnSolutionRunner_ShouldReturn_400()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var haskellServiceSub = scope.ServiceProvider.GetService<IHaskellService>();
+        var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
+
+        exerciseRepoSub.VerifyExerciseAuthorAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+        var solutionRunnerResponse = new SolutionRunnerResponse
+        {
+            Action = ResponseCode.Error,
+            ResponseDto = new SolutionResponseDto("error", "compilation error", null)
+        };
+        haskellServiceSub.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(solutionRunnerResponse);
+        exerciseRepoSub.UpdateExerciseAsync(Arg.Any<ExerciseDto>(), Arg.Any<int>()).Returns(Result.Ok());
+
+        var userId = 1;
+        var roles = new List<Roles> { Roles.Instructor };
+        _client.AddRoleAuth(userId, roles);
+        var requestBody = CreateExerciseRequestBody();
+
+        var response = await _client.PutAsync("v1/exercises/1", requestBody);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteExercise_ShouldReturn_204()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
+
+        exerciseRepoSub.VerifyExerciseAuthorAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+        exerciseRepoSub.DeleteExerciseAsync(Arg.Any<int>()).Returns(true);
+
+        var userId = 1;
+        var roles = new List<Roles> { Roles.Instructor };
+        _client.AddRoleAuth(userId, roles);
+
+        var response = await _client.DeleteAsync("/v1/exercises/1");
+
+        Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteExercise_RepositoryFailedToDelete_ShouldReturn_404()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var exerciseRepoSub = scope.ServiceProvider.GetService<IExerciseRepository>();
+
+        exerciseRepoSub.VerifyExerciseAuthorAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+        exerciseRepoSub.DeleteExerciseAsync(Arg.Any<int>()).Returns(false);
+
+        var userId = 1;
+        var roles = new List<Roles> { Roles.Instructor };
+        _client.AddRoleAuth(userId, roles);
+
+        var response = await _client.DeleteAsync("/v1/exercises/1");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SubmitSolutionProposal_ShouldReturn_200()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var solutionRepoSub = scope.ServiceProvider.GetService<ISolutionRepository>();
+        var haskellServiceSub = scope.ServiceProvider.GetService<IHaskellService>();
+
+        solutionRepoSub.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+        var testcasesResponse = new List<Testcase> { new Testcase { TestCaseId = 1, IsPublicVisible = true, Input = { new TestParameter { ParameterType = "int", ParameterValue = "1" } }, Output = { new TestParameter { ParameterType = "int", ParameterValue = "1" } } } };
+        solutionRepoSub.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(testcasesResponse);
+        var solutionRunnerResponse = new SolutionRunnerResponse { Action = ResponseCode.Pass };
+        haskellServiceSub.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(solutionRunnerResponse);
+        solutionRepoSub.InsertSolvedRelation(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+
+        var userId = 1;
+        var roles = new List<Roles> { Roles.AnonymousUser };
+        _client.AddRoleAuth(userId, roles);
+        var requestBody = new SubmitSolutionDto(1, "x + y");
+        var jsonBody = new StringContent(
+            System.Text.Json.JsonSerializer.Serialize(requestBody),
+            Encoding.UTF8,
+            "application/json"
+        );
+
+        var response = await _client.PostAsync("/v1/exercises/1/submission", jsonBody);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SubmitSolutionProposal_SolutionProposalFailed_ShouldReturn_500()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var solutionRepoSub = scope.ServiceProvider.GetService<ISolutionRepository>();
+        var haskellServiceSub = scope.ServiceProvider.GetService<IHaskellService>();
+
+        solutionRepoSub.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+        var testcasesResponse = new List<Testcase> { new Testcase { TestCaseId = 1, IsPublicVisible = true, Input = { new TestParameter { ParameterType = "int", ParameterValue = "1" } }, Output = { new TestParameter { ParameterType = "int", ParameterValue = "1" } } } };
+        solutionRepoSub.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(testcasesResponse);
+        var solutionRunnerResponse = new SolutionRunnerResponse
+        {
+            Action = ResponseCode.Failure,
+            ResponseDto = new SolutionResponseDto("failure", null, new List<SolutionTestcaseResultDto> { new SolutionTestcaseResultDto(5, "test", null, null) })
+        };
+        haskellServiceSub.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(solutionRunnerResponse);
+        solutionRepoSub.InsertSolvedRelation(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+
+        var userId = 1;
+        var roles = new List<Roles> { Roles.AnonymousUser };
+        _client.AddRoleAuth(userId, roles);
+        var requestBody = new SubmitSolutionDto(1, "x + y");
+        var jsonBody = new StringContent(
+            System.Text.Json.JsonSerializer.Serialize(requestBody),
+            Encoding.UTF8,
+            "application/json"
+        );
+
+        var response = await _client.PostAsync("/v1/exercises/1/submission", jsonBody);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SubmitSolutionProposal_UserNotAssociatedToSession_ShouldReturn_500()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var solutionRepoSub = scope.ServiceProvider.GetService<ISolutionRepository>();
+        var haskellServiceSub = scope.ServiceProvider.GetService<IHaskellService>();
+
+        solutionRepoSub.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(false);
+        var testcasesResponse = new List<Testcase> { new Testcase { TestCaseId = 1, IsPublicVisible = true, Input = { new TestParameter { ParameterType = "int", ParameterValue = "1" } }, Output = { new TestParameter { ParameterType = "int", ParameterValue = "1" } } } };
+        solutionRepoSub.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(testcasesResponse);
+        var solutionRunnerResponse = new SolutionRunnerResponse { Action = ResponseCode.Pass };
+        haskellServiceSub.SubmitSubmission(Arg.Any<SubmissionDto>()).Returns(solutionRunnerResponse);
+        solutionRepoSub.InsertSolvedRelation(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+
+        var userId = 1;
+        var roles = new List<Roles> { Roles.AnonymousUser };
+        _client.AddRoleAuth(userId, roles);
+        var requestBody = new SubmitSolutionDto(1, "x + y");
+        var jsonBody = new StringContent(
+            System.Text.Json.JsonSerializer.Serialize(requestBody),
+            Encoding.UTF8,
+            "application/json"
+        );
+
+        var response = await _client.PostAsync("/v1/exercises/1/submission", jsonBody);
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+
+    private StringContent CreateExerciseRequestBody()
+    {
+        var requestBody = new
         {
             Name = "Sum of Two Numbers",
             Description = "A function that calculates the sum of two integers.",
@@ -282,6 +478,12 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
                 new { InputParams = new[] { "-1" }, OutputParams = new[] { "1" }, PublicVisible = false }
             }
         };
+
+        return new StringContent(
+            System.Text.Json.JsonSerializer.Serialize(requestBody),
+            Encoding.UTF8,
+            "application/json"
+        );
     }
 
 }

--- a/IntegrationTest/SessionEndpointsTest.cs
+++ b/IntegrationTest/SessionEndpointsTest.cs
@@ -66,10 +66,9 @@ public class SessionEndpointsTest: IClassFixture<TestWebApplicationFactory<Progr
     	sessionSub!.GetSessionsAsync(Arg.Any<int>()).Returns(new List<Session>{new Session{Title = "Hello"}}); 
     	var userId = 1;
     	var roles = new List<Roles> { Roles.AnonymousUser};
-    	_client.AddRoleAuth(1, roles);
+    	_client.AddRoleAuth(userId, roles);
     	
     	var response = await _client.GetAsync("/v1/sessions");
-    	
     	
     	Assert.Equal(HttpStatusCode.Forbidden,response.StatusCode);
     }

--- a/IntegrationTest/SessionEndpointsTest.cs
+++ b/IntegrationTest/SessionEndpointsTest.cs
@@ -198,7 +198,7 @@ public class SessionEndpointsTest: IClassFixture<TestWebApplicationFactory<Progr
         _client.AddRoleAuth(userId, roles);
         var requestBody = CreateSessionDtoInput();
 
-        var response = await _client.PostAsync("/v1/sessions", requestBody);
+        var response = await _client.PostAsJsonAsync("/v1/sessions", requestBody);
 
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         var body = await response.Content.ReadFromJsonAsync<CreateSessionResponseDto>();
@@ -219,7 +219,7 @@ public class SessionEndpointsTest: IClassFixture<TestWebApplicationFactory<Progr
         _client.AddRoleAuth(userId, roles);
         var requestBody = CreateSessionDtoInput();
 
-        var response = await _client.PostAsync("/v1/sessions", requestBody);
+        var response = await _client.PostAsJsonAsync("/v1/sessions", requestBody);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -234,7 +234,7 @@ public class SessionEndpointsTest: IClassFixture<TestWebApplicationFactory<Progr
 
         var requestBody = CreateSessionDtoInput();
 
-        var response = await _client.PostAsync("/v1/sessions", requestBody);
+        var response = await _client.PostAsJsonAsync("/v1/sessions", requestBody);
 
         Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
@@ -249,13 +249,9 @@ public class SessionEndpointsTest: IClassFixture<TestWebApplicationFactory<Progr
         sessionRepoSub.GetSessionBySessionCodeAsync(Arg.Any<string>()).Returns(sessionResponse);
         sessionRepoSub.CreateAnonUser(Arg.Any<int>()).Returns(1);
 
-        var requestBody = new StringContent(
-            System.Text.Json.JsonSerializer.Serialize(new JoinSessionDto("AA1234")),
-            Encoding.UTF8,
-            "application/json"
-        );
+        var requestBody = new JoinSessionDto("AA1234");
 
-        var response = await _client.PostAsync("/join", requestBody);
+        var response = await _client.PostAsJsonAsync("/join", requestBody);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var body = await response.Content.ReadFromJsonAsync<JoinSessionResponseDto>();
@@ -272,13 +268,9 @@ public class SessionEndpointsTest: IClassFixture<TestWebApplicationFactory<Progr
         sessionRepoSub.GetSessionBySessionCodeAsync(Arg.Any<string>()).Returns(Result.Fail("Found no session on session code"));
         sessionRepoSub.CreateAnonUser(Arg.Any<int>()).Returns(1);
 
-        var requestBody = new StringContent(
-            System.Text.Json.JsonSerializer.Serialize(new JoinSessionDto("AA1234")),
-            Encoding.UTF8,
-            "application/json"
-        );
+        var requestBody = new JoinSessionDto("AA1234");
 
-        var response = await _client.PostAsync("/join", requestBody);
+        var response = await _client.PostAsJsonAsync("/join", requestBody);
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
@@ -307,19 +299,13 @@ public class SessionEndpointsTest: IClassFixture<TestWebApplicationFactory<Progr
         };
     }
 
-    private StringContent CreateSessionDtoInput()
+    private CreateSessionDto CreateSessionDtoInput()
     {
-        var requestBody = new CreateSessionDto(
+        return new CreateSessionDto(
             Title: "Number sum",
             Description: "Basic exercise",
             ExpiresInHours: 5,
             ExerciseIds: new List<int> { 101 }
-        );
-
-        return new StringContent(
-            System.Text.Json.JsonSerializer.Serialize(requestBody),
-            Encoding.UTF8,
-            "application/json"
         );
     }
 }

--- a/IntegrationTest/SessionEndpointsTest.cs
+++ b/IntegrationTest/SessionEndpointsTest.cs
@@ -12,12 +12,12 @@ using NSubstitute;
 namespace IntegrationTest;
 
 [Collection(CollectionDefinitions.NonParallelCollectionName)]
-public class SessionEndpoints: IClassFixture<TestWebApplicationFactory<Program>>
+public class SessionEndpointsTest: IClassFixture<TestWebApplicationFactory<Program>>
 {
 	private readonly HttpClient _client;
 	private readonly TestWebApplicationFactory<Program> _factory;
 
-	public SessionEndpoints(TestWebApplicationFactory<Program> factory)
+	public SessionEndpointsTest(TestWebApplicationFactory<Program> factory)
 	{
 		_factory = factory;
 		_client = factory.CreateClient();

--- a/IntegrationTest/Setup/TestWebApplicationFactory.cs
+++ b/IntegrationTest/Setup/TestWebApplicationFactory.cs
@@ -1,5 +1,7 @@
+using Core.Exercises.Contracts;
 using Core.Sessions.Contracts;
 using Core.Shared;
+using Core.Solutions.Models;
 using Infrastructure;
 using Infrastructure.Authentication;
 using Infrastructure.Authentication.Contracts;
@@ -32,7 +34,11 @@ public class TestWebApplicationFactory<TProgram> : WebApplicationFactory<TProgra
 		{
 			Environment.SetEnvironmentVariable(AuthConstants.JwtSecret, "sdafdafdfasdfasdfasdfasfdasfdafdf"); 
 			var iSesSub = Substitute.For<ISessionRepository>();
-			services.AddScoped<ISessionRepository>(_ => iSesSub);
+            var iExeciseSub = Substitute.For<IExerciseRepository>();
+			var iHaskellSubstitute = Substitute.For<IHaskellService>();
+            services.AddScoped<ISessionRepository>(_ => iSesSub);
+			services.AddScoped<IExerciseRepository>(_ => iExeciseSub);
+			services.AddScoped<IHaskellService>(_ => iHaskellSubstitute);
 		});
 		
 		return base.CreateHost(builder);

--- a/IntegrationTest/Setup/TestWebApplicationFactory.cs
+++ b/IntegrationTest/Setup/TestWebApplicationFactory.cs
@@ -37,11 +37,11 @@ public class TestWebApplicationFactory<TProgram> : WebApplicationFactory<TProgra
 			var iSesSub = Substitute.For<ISessionRepository>();
             var iExeciseSub = Substitute.For<IExerciseRepository>();
 			var iHaskellSub = Substitute.For<IHaskellService>();
-			var isolutionSub = Substitute.For<ISolutionRepository>();
+			var iSolutionSub = Substitute.For<ISolutionRepository>();
             services.AddScoped<ISessionRepository>(_ => iSesSub);
 			services.AddScoped<IExerciseRepository>(_ => iExeciseSub);
 			services.AddScoped<IHaskellService>(_ => iHaskellSub);
-			services.AddScoped<ISolutionRepository>(_ => isolutionSub);
+			services.AddScoped<ISolutionRepository>(_ => iSolutionSub);
 		});
 		
 		return base.CreateHost(builder);

--- a/IntegrationTest/Setup/TestWebApplicationFactory.cs
+++ b/IntegrationTest/Setup/TestWebApplicationFactory.cs
@@ -1,6 +1,7 @@
 using Core.Exercises.Contracts;
 using Core.Sessions.Contracts;
 using Core.Shared;
+using Core.Solutions.Contracts;
 using Core.Solutions.Models;
 using Infrastructure;
 using Infrastructure.Authentication;
@@ -35,10 +36,12 @@ public class TestWebApplicationFactory<TProgram> : WebApplicationFactory<TProgra
 			Environment.SetEnvironmentVariable(AuthConstants.JwtSecret, "sdafdafdfasdfasdfasdfasfdasfdafdf"); 
 			var iSesSub = Substitute.For<ISessionRepository>();
             var iExeciseSub = Substitute.For<IExerciseRepository>();
-			var iHaskellSubstitute = Substitute.For<IHaskellService>();
+			var iHaskellSub = Substitute.For<IHaskellService>();
+			var isolutionSub = Substitute.For<ISolutionRepository>();
             services.AddScoped<ISessionRepository>(_ => iSesSub);
 			services.AddScoped<IExerciseRepository>(_ => iExeciseSub);
-			services.AddScoped<IHaskellService>(_ => iHaskellSubstitute);
+			services.AddScoped<IHaskellService>(_ => iHaskellSub);
+			services.AddScoped<ISolutionRepository>(_ => isolutionSub);
 		});
 		
 		return base.CreateHost(builder);

--- a/UnitTest/Core/Sessions/SessionServiceTest.cs
+++ b/UnitTest/Core/Sessions/SessionServiceTest.cs
@@ -4,6 +4,7 @@ using Core.Sessions.Contracts;
 using Core.Sessions.Models;
 using Core.Shared;
 using Core.Shared.Contracts;
+using FluentResults;
 using Infrastructure.Authentication;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -199,7 +200,7 @@ public class SessionServiceTest
         var sessionService = new SessionService(sessionRepoSub, loggerSub, tokenServiceSub);
 
         var session = new Session();
-        sessionRepoSub.GetSessionBySessionCodeAsync(Arg.Any<string>()).Returns(Task.FromResult<Session?>(null));
+        sessionRepoSub.GetSessionBySessionCodeAsync(Arg.Any<string>()).Returns(Result.Fail("Failed to get session"));
         
         var dto = new JoinSessionDto("token");
         var result = await sessionService.JoinSessionAnonUser(dto);

--- a/UnitTest/Core/Solutions/SolutionRunnerServiceTest.cs
+++ b/UnitTest/Core/Solutions/SolutionRunnerServiceTest.cs
@@ -31,7 +31,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnnerService(loggerSub, haskellService, solutionRepo);
         var dto = new SubmitSolutionDto(1, "test");
 
-        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>()).Returns(false);
+        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(false);
 
         var result = await runner.SubmitSolutionAsync(dto, exerciseId: 1, userId: 2);
 
@@ -53,7 +53,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnnerService(loggerSub, haskellService, solutionRepo);
         var dto = new SubmitSolutionDto(1, "test");
 
-        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>()).Returns(true);
+        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepo.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(Task.FromResult<List<Testcase>?>(null));
 
         var result = await runner.SubmitSolutionAsync(dto, exerciseId: 1, userId: 2);
@@ -76,7 +76,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnnerService(loggerSub, haskellService, solutionRepo);
         var dto = new SubmitSolutionDto(1, "test");
 
-        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>()).Returns(true);
+        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepo.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(Task.FromResult<List<Testcase>?>(new List<Testcase>()));
 
         var result = await runner.SubmitSolutionAsync(dto, exerciseId: 1, userId: 2);
@@ -100,7 +100,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnnerService(loggerSub, haskellService, solutionRepo);
         var dto = new SubmitSolutionDto(1, "test");
 
-        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>()).Returns(true);
+        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepo.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(Task.FromResult<List<Testcase>?>(new List<Testcase>()));
 
         var result = await runner.SubmitSolutionAsync(dto, exerciseId: 1, userId: 2);
@@ -125,7 +125,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnnerService(loggerSub, haskellService, solutionRepo);
         var dto = new SubmitSolutionDto(1, "test");
 
-        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>()).Returns(true);
+        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepo.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(Task.FromResult<List<Testcase>?>(new List<Testcase>()));
 
         var result = await runner.SubmitSolutionAsync(dto, exerciseId: 1, userId: 2);
@@ -150,7 +150,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnnerService(loggerSub, haskellService, solutionRepo);
         var dto = new SubmitSolutionDto(1, "test");
 
-        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>()).Returns(true);
+        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepo.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(Task.FromResult<List<Testcase>?>(new List<Testcase>()));
         solutionRepo.InsertSolvedRelation(Arg.Any<int>(), Arg.Any<int>()).Returns(false);
 
@@ -175,7 +175,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnnerService(loggerSub, haskellService, solutionRepo);
         var dto = new SubmitSolutionDto(1, "test");
 
-        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>()).Returns(true);
+        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepo.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(Task.FromResult<List<Testcase>?>(new List<Testcase>()));
         solutionRepo.InsertSolvedRelation(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
 


### PR DESCRIPTION
## Description
Add integration testing to the exercise- and session endpoints.

### Resolved Issue
Fixes #102 

## Changes
- Adds integration tests for all exercise endpoints.
- Adds integration tests for all session endpoints.
- Modifies `CheckAnonUserExistsInSessionAsync` of SessionRepository to also include session id as parameter, to validate that user exists in that specific session, and not just any session.

## Checklist
- [X] I have added test cases for my additions
- [X] New and old tests passed
- [ ] Documentation is updated
