### PR TITLE
Fixes #150 solved is removed from instructor get session endpoint

### DIFF
--- a/.bruno/Sessions/GetSessionByInstructor.bru
+++ b/.bruno/Sessions/GetSessionByInstructor.bru
@@ -1,0 +1,15 @@
+meta {
+  name: GetSessionByInstructor
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{baseURL}}/{{currentVersion}}/sessions/{{sessionId}}
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{instructorToken}}
+}

--- a/Core/Exercises/Models/SolvedExercise.cs
+++ b/Core/Exercises/Models/SolvedExercise.cs
@@ -4,6 +4,6 @@ public class SolvedExercise
 {
     public int ExerciseId { get; set; }
     public string ExerciseTitle { get; set; } = string.Empty;
-    public bool Solved { get; set; }
+    public bool? Solved { get; set; }
 }
 

--- a/Core/Exercises/Models/SolvedExerciseDto.cs
+++ b/Core/Exercises/Models/SolvedExerciseDto.cs
@@ -1,3 +1,9 @@
+using System.Text.Json.Serialization;
+
 namespace Core.Exercises.Models;
 
-public record SolvedExerciseDto(int Id, string Name, bool Solved);
+public record SolvedExerciseDto(
+	int Id, 
+	string Name,
+	[property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	bool? Solved);

--- a/Core/Sessions/Models/GetSessionResponseDto.cs
+++ b/Core/Sessions/Models/GetSessionResponseDto.cs
@@ -3,6 +3,12 @@ using Core.Languages.Models;
 
 namespace Core.Sessions.Models;
 
-public record GetSessionResponseDto(string Title, string? Description, string Author, DateTime SessionExpiresUtc, List<SolvedExerciseDto> Exercises, List<GetLanguagesResponseDto> Languages);
+public record GetSessionResponseDto(
+	string Title, 
+	string? Description, 
+	string Author, 
+	DateTime SessionExpiresUtc, 
+	List<SolvedExerciseDto> Exercises, 
+	List<GetLanguagesResponseDto> Languages);
 
 

--- a/Core/Sessions/Models/Session.cs
+++ b/Core/Sessions/Models/Session.cs
@@ -43,7 +43,7 @@ public static class SessionMapper
     public static GetSessionResponseDto ConvertToGetResponse(this Session session)
     {
         return new GetSessionResponseDto(session.Title, session.Description, session.AuthorName,
-           session.ExpirationTimeUtc, session.ExerciseDetails.Select(x => new SolvedExerciseDto(x.ExerciseId, x.ExerciseTitle, x.Solved)).ToList(),
+           session.ExpirationTimeUtc, session.ExerciseDetails.Select(x => new SolvedExerciseDto(x.ExerciseId, x.ExerciseTitle, x.Solved!)).ToList(),
            session.LanguagesModel.Select(x => new GetLanguagesResponseDto(x.Id, x.Language)).ToList()
            );
     }

--- a/Core/Sessions/SessionService.cs
+++ b/Core/Sessions/SessionService.cs
@@ -188,6 +188,11 @@ public class SessionService : ISessionService
             return Result.Fail("Session does not exist");
         }
 
+        if (role == Roles.Instructor)
+        {
+            session.ExerciseDetails.ForEach(e => e.Solved = null);
+        }
+
         
         return session.ConvertToGetResponse();
     }


### PR DESCRIPTION
## Description

Remove the solved field when an instructor accesses the endpoint for getting a specific session.

### Resolved Issue
Fixes #150

## Changes

Changed field to nullable and discriminate the solved filed based on the role.

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [X] New and old tests passed
