### PR TITLE
Fixes #151, roomcode and isopen no longer gets served to students

### DIFF
--- a/API/Endpoints/ClassroomEndpoints.cs
+++ b/API/Endpoints/ClassroomEndpoints.cs
@@ -55,13 +55,20 @@ public static class ClassroomEndpoints
 
         classroomV2.MapGet("/{classroomId:int}", async Task<Results<Ok<GetClassroomResponseDto>, BadRequest<ValidationProblemDetails>>> (int classroomId, ClaimsPrincipal principal, IClassroomService service) =>
         {
-            var userId = principal.Claims.First(c => c.Type == ClaimTypes.UserData).Value;
+            var role = RolesConvert.Convert(principal.Claims.First(c => c.Type == ClaimTypes.Role).Value);
             var result = await service.GetClassroomById(classroomId);
             if(result.IsFailed)
             {
                 return TypedResults.BadRequest(CreateBadRequest.CreateValidationProblemDetails(result.Errors, "Errors", "Errors"));
             }
 
+            if (role == Roles.Student)
+            {
+                result.Value.Roomcode = null;
+                result.Value.IsOpen = null;
+            }
+            
+            
             return TypedResults.Ok(result.Value);
 
         }).RequireAuthorization(Policies.AllowClassroomRoles);

--- a/Core/Classrooms/Models/GetClassroomResponseDto.cs
+++ b/Core/Classrooms/Models/GetClassroomResponseDto.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace Core.Classrooms.Models;
@@ -12,8 +13,10 @@ public class GetClassroomResponseDto
     public int Id { get; set; }
     public string Title { get; set; } = string.Empty;
     public string? Description { get; set; } = string.Empty;
-    public string Roomcode { get; set; } = string.Empty;
-    public bool IsOpen { get; set; } 
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Roomcode { get; set; }
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? IsOpen { get; set; } 
     public int TotalStudents { get; set; }
     public List<GetClassroomSessionDto> Sessions { get; set; } = new();
 }


### PR DESCRIPTION
## Description

RoomCode and IsOpen is no longer served to the frontend if a student uses the getendpoint. 

### Resolved Issue
Fixes #151


## Checklist

- [X] New and old tests passed
