### PR TITLE
Frontendfix

### DIFF
--- a/API/Endpoints/SessionEndpoints.cs
+++ b/API/Endpoints/SessionEndpoints.cs
@@ -46,13 +46,15 @@ public static class SessionEndpoints
             async Task<Results<Ok<List<GetSessionsResponseDto>>, NotFound, BadRequest>> (ClaimsPrincipal principal,
                 ISessionService sessionService) =>
             {
-                var userId = principal.FindFirst( ClaimTypes.UserData)?.Value;
-                if (userId == null)
+                var userId = principal.FindFirst(ClaimTypes.UserData)?.Value;
+                var userRoles = principal.FindFirst(x => x.Type == ClaimTypes.Role)?.Value;
+
+                if (userId == null || userRoles == null)
                 {
                     return TypedResults.BadRequest();
                 }
 
-                var results = await sessionService.GetSessions(Convert.ToInt32(userId));
+                var results = await sessionService.GetSessions(Convert.ToInt32(userId), RolesConvert.Convert(userRoles));
                 if (results.IsFailed)
                 {
                     return TypedResults.NotFound();
@@ -64,7 +66,7 @@ public static class SessionEndpoints
         sessionV1Group.MapGet("/{id:int}", async Task<Results<Ok<GetSessionResponseDto>, NotFound, BadRequest>>(int id, ClaimsPrincipal principal, ISessionService service) =>
         {
 
-            var userId = principal.FindFirst( ClaimTypes.UserData)?.Value;
+            var userId = principal.FindFirst(ClaimTypes.UserData)?.Value;
             var userRoles = principal.FindFirst(x => x.Type == ClaimTypes.Role)?.Value;
             if (userRoles == null)
             {

--- a/API/Endpoints/UserEndpoints.cs
+++ b/API/Endpoints/UserEndpoints.cs
@@ -34,17 +34,12 @@ public static class UserEndpoints
 				var strRole = principal.FindFirst(ClaimTypes.Role)?.Value;
 				var actualRole = RolesConvert.Convert(strRole!);
 
-				if (actualRole == Roles.AnonymousUser)
+				var user = actualRole switch
 				{
-					var anonDetails = await service.GetAnonUserByIdAsync(actualUserId);
-					if (anonDetails.IsFailed)
-					{
-						return TypedResults.NotFound();
-					}
-					return TypedResults.Ok(anonDetails.Value);
-				}
-				
-				var user = await service.GetAppUserByIdAsync(actualUserId);
+					Roles.AnonymousUser => await service.GetAnonUserByIdAsync(actualUserId),
+					_ => await service.GetAppUserByIdAsync(actualUserId)
+				};
+			
 				if (user.IsFailed)
 				{
 					return TypedResults.NotFound();

--- a/Core/Sessions/Contracts/ISessionRepository.cs
+++ b/Core/Sessions/Contracts/ISessionRepository.cs
@@ -23,7 +23,6 @@ public interface ISessionRepository
     Task<bool> VerifyLanguagesIdsAsync(List<Language> languages);
     Task<Result> InsertExerciseRelation(List<int> exerciseIds, int sessionId, IDbConnection con, IDbTransaction transaction);
     Task<Result> InsertLanguageRelation(List<int> languageIds, int sessionId, IDbConnection con, IDbTransaction transaction);
-    Task<Result> StudentJoinSession(string code, int userId);
-
+    Task<Result<int>> StudentJoinSession(string code, int userId);
     Task<int> GetTimedSessionIdByUserId(int userId);
 }

--- a/Core/Sessions/Contracts/ISessionRepository.cs
+++ b/Core/Sessions/Contracts/ISessionRepository.cs
@@ -17,7 +17,8 @@ public interface ISessionRepository
     Task DeleteExpiredSessions();
     Task<Result<Session>> GetSessionBySessionCodeAsync(string sessionCode);
     Task<Session?> GetSessionOverviewAsync(int sessionId, int userId);
-    Task<IEnumerable<Session>?> GetSessionsAsync(int authorId);
+    Task<List<Session>?> GetInstructorSessionsAsync(int authorId);
+    Task<List<Session>?> GetStudentSessionsAsync(int studentId);
     Task<bool> DeleteSessionAsync(int sessionId, int authorId);
     Task<bool> VerifyExerciseIdsAsync(List<int> exerciseIds, int authorId, IDbConnection con, IDbTransaction transaction);
     Task<bool> VerifyLanguagesIdsAsync(List<Language> languages);

--- a/Core/Sessions/Contracts/ISessionService.cs
+++ b/Core/Sessions/Contracts/ISessionService.cs
@@ -9,7 +9,7 @@ public interface ISessionService
     Task<Result<CreateSessionResponseDto>> CreateSessionAsync(CreateSessionDto sessionDto, int authorId);
     Task<Result<JoinResponseDto>> JoinSessionAnonUser(JoinDto dto);
     Task<Result<GetSessionResponseDto>> GetSessionByIdAsync(int sessionId, int userId, Roles role);
-    Task<Result<List<GetSessionsResponseDto>>> GetSessions(int userId);
+    Task<Result<List<GetSessionsResponseDto>>> GetSessions(int userId, Roles role);
     Task<Result<JoinResponseDto>> JoinStudent(int userId, string code);
     Task<Result> DeleteSession(int sessionId, int userId);
 }

--- a/Core/Sessions/Models/JoinResponseDto.cs
+++ b/Core/Sessions/Models/JoinResponseDto.cs
@@ -9,13 +9,12 @@ public record JoinResponseDto(
 	DateTime? ExpiresAt,
 	JoinedType JoinedType,
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	int? ClassroomId
-
+	int? JoinedId
     );
 
 // NOT SURE WHERE TO PLACE THIS ENUM
 public enum JoinedType
 {
-	JoinedTimedSession = 1,
-	JoinedClassroom = 2
+	TimedSession = 1,
+	Classroom = 2
 }

--- a/Core/Sessions/Models/Session.cs
+++ b/Core/Sessions/Models/Session.cs
@@ -17,7 +17,6 @@ public class Session
     public List<int> Exercises { get; set; } = new (); // this needs to be changed when exercises are available
     public List<SolvedExercise> ExerciseDetails { get; set; } = new();
     public List<Language> Languages { get; set; } = new();
-
     public List<LanguageSupport> LanguagesModel { get; set; } = new();
 }
 

--- a/Core/Sessions/SessionService.cs
+++ b/Core/Sessions/SessionService.cs
@@ -113,9 +113,9 @@ public class SessionService : ISessionService
         var result = await _sessionRepository.StudentJoinSession(code, userId);
         if (result.IsFailed)
         {
-            return result;
+            return Result.Fail(result.Errors);
         }
-        return new JoinResponseDto(null, null, JoinedType.JoinedTimedSession, null);
+        return new JoinResponseDto(null, null, JoinedType.TimedSession, result.Value);
     }
 
     private async Task<Result<JoinResponseDto>> JoinClassRoomStudent(int studentId, string code)
@@ -125,7 +125,7 @@ public class SessionService : ISessionService
         {
             return Result.Fail(result.Errors);
         }
-        return new JoinResponseDto(null, null, JoinedType.JoinedClassroom, result.Value);
+        return new JoinResponseDto(null, null, JoinedType.Classroom, result.Value);
     }
 
     public enum Codes
@@ -169,7 +169,7 @@ public class SessionService : ISessionService
         var timeOffset = session.Value.ExpirationTimeUtc - DateTime.UtcNow;
         
         var createToken = _tokenService.GenerateAnonymousUserJwt((int)Math.Ceiling(timeOffset.TotalMinutes), student);
-        return new JoinResponseDto(createToken, DateTime.UtcNow.AddMinutes((int)Math.Ceiling(timeOffset.TotalMinutes)), JoinedType.JoinedTimedSession, null);
+        return new JoinResponseDto(createToken, DateTime.UtcNow.AddMinutes((int)Math.Ceiling(timeOffset.TotalMinutes)), JoinedType.TimedSession, null);
     }
 
     public async Task<Result<GetSessionResponseDto>> GetSessionByIdAsync(int sessionId, int userId, Roles role)

--- a/Core/Sessions/SessionService.cs
+++ b/Core/Sessions/SessionService.cs
@@ -35,9 +35,14 @@ public class SessionService : ISessionService
         return Result.Ok();
     }
     
-    public async Task<Result<List<GetSessionsResponseDto>>> GetSessions(int userId)
+    public async Task<Result<List<GetSessionsResponseDto>>> GetSessions(int userId, Roles role)
     {
-        var sessions = await _sessionRepository.GetSessionsAsync(userId);
+        var sessions = role switch
+        {
+            Roles.Instructor => await _sessionRepository.GetInstructorSessionsAsync(userId),
+            Roles.Student => await _sessionRepository.GetStudentSessionsAsync(userId),
+            _ => null
+        };
         if (sessions == null)
         {
             return Result.Fail("Sessions not found");

--- a/Infrastructure/Authentication/UserService.cs
+++ b/Infrastructure/Authentication/UserService.cs
@@ -65,7 +65,13 @@ public class UserService : IUserService
 			_logger.LogWarning("Could not retrieve user {userid}", id);
 			return Result.Fail("Error getting user");
 		}
-		return Result.Ok(new GetUserResponseDto(result.Value.Email, result.Value.Name, null));
+        var sessionId = await _sessionRepository.GetTimedSessionIdByUserId(id);
+        if (sessionId == 0)
+        {
+            return Result.Ok(new GetUserResponseDto(result.Value.Email, result.Value.Name, null));
+        }
+
+        return Result.Ok(new GetUserResponseDto(result.Value.Email, result.Value.Name, sessionId));
 	}
 
 	public async Task<Result<GetUserResponseDto>> GetAnonUserByIdAsync(int userId)

--- a/Infrastructure/ClassroomRepository.cs
+++ b/Infrastructure/ClassroomRepository.cs
@@ -154,7 +154,7 @@ public class ClassroomRepository : IClassroomRepository
         using var con = await _connection.CreateConnectionAsync();
 
         var query = """
-                    SELECT classroom_id AS id, title, description 
+                    SELECT c.classroom_id AS id, title, description 
                     FROM classroom AS c
                     JOIN student_in_classroom AS sic
                     ON c.classroom_id = sic.classroom_id

--- a/Infrastructure/ClassroomRepository.cs
+++ b/Infrastructure/ClassroomRepository.cs
@@ -2,6 +2,7 @@
 using Core.Classrooms.Models;
 using Core.Languages.Models;
 using Core.Sessions.Contracts;
+using Core.Sessions.Models;
 using Dapper;
 using FluentResults;
 using Infrastructure.Persistence.Contracts;
@@ -288,7 +289,7 @@ public class ClassroomRepository : IClassroomRepository
         {
             transaction.Rollback();
             _logger.LogInformation("User {userID} failed to join classroom {classroomID} - registration not open", studentId, classroomId);
-            return Result.Fail("Classroom cannot not open to join");
+            return Result.Fail("Classroom not open to join");
         }
 
         var checkJoinedQuery = "SELECT 1 FROM student_in_classroom WHERE student_id = @StudentId AND classroom_id = @ClassroomId";
@@ -297,7 +298,7 @@ public class ClassroomRepository : IClassroomRepository
         {
             transaction.Rollback();
             _logger.LogInformation("User {userID} tried to join classroom {classroomId}, but was already joined", studentId, classroomId);
-            return Result.Fail("Student already joined classroom");
+            return Result.Ok(classroomId);
         }
 
         var query = "INSERT INTO student_in_classroom (student_id, classroom_id) VALUES (@StudentId, @ClassroomId);";

--- a/Infrastructure/Persistence/Scripts/002-V2Migrations.sql
+++ b/Infrastructure/Persistence/Scripts/002-V2Migrations.sql
@@ -44,7 +44,7 @@ CREATE TABLE language_in_session (
 );
 
 CREATE TABLE user_in_timedsession (
-    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE UNIQUE,
     session_id INTEGER REFERENCES session(session_id) ON DELETE CASCADE,
     PRIMARY KEY (user_id, session_id)
 );

--- a/Infrastructure/SessionRepository.cs
+++ b/Infrastructure/SessionRepository.cs
@@ -366,7 +366,7 @@ public class SessionRepository : ISessionRepository
         return exercises.OrderBy(x => x.ExerciseId).ToList();
     }
 
-    public async Task<IEnumerable<Session>?> GetSessionsAsync(int authorId)
+    public async Task<List<Session>?> GetInstructorSessionsAsync(int authorId)
     {
         using var con = await _connection.CreateConnectionAsync();
         var query = """
@@ -380,7 +380,20 @@ public class SessionRepository : ISessionRepository
                     );
                     """;
         var results = await con.QueryAsync<Session>(query, new { Id = authorId });
-        return results;
+        return results.ToList();
+    }
+
+    public async Task<List<Session>?> GetStudentSessionsAsync(int studentId)
+    {
+        using var con = await _connection.CreateConnectionAsync();
+        var query = """
+                    SELECT s.session_id AS id, title, expirationtime_utc AS ExpirationTimeUtc
+                    FROM session AS s
+                    JOIN user_in_timedsession as sit ON s.session_id = sit.session_id
+                    WHERE user_id = @StudentId
+                    """;
+        var result = await con.QueryAsync<Session>(query, new { StudentId = studentId });
+        return result.ToList();
     }
 
     public async Task<bool> DeleteSessionAsync(int sessionId, int authorId)

--- a/IntegrationTest/SessionEndpointsTest.cs
+++ b/IntegrationTest/SessionEndpointsTest.cs
@@ -33,7 +33,7 @@ public class SessionEndpointsTest: IClassFixture<TestWebApplicationFactory<Progr
 	{
         using var scope = _factory.Services.CreateScope();
         var sessionSub = scope.ServiceProvider.GetService<ISessionRepository>();
-		sessionSub!.GetSessionsAsync(Arg.Any<int>()).Returns(new List<Session>{new Session{Title = "Hello"}});
+		sessionSub!.GetInstructorSessionsAsync(Arg.Any<int>()).Returns(new List<Session>{new Session{Title = "Hello"}});
 		var userId = 1;
 		var roles = new List<Roles> { Roles.Instructor};
 		_client.AddRoleAuth(userId, roles);
@@ -51,7 +51,7 @@ public class SessionEndpointsTest: IClassFixture<TestWebApplicationFactory<Progr
     {
         using var scope = _factory.Services.CreateScope();
         var sessionSub = scope.ServiceProvider.GetService<ISessionRepository>();
-    	sessionSub!.GetSessionsAsync(Arg.Any<int>()).Returns(Task.FromResult<IEnumerable<Session>?>(null));
+    	sessionSub!.GetInstructorSessionsAsync(Arg.Any<int>()).Returns(Task.FromResult<List<Session>?>(null));
     	var userId = 1;
     	var roles = new List<Roles> { Roles.Instructor};
     	_client.AddRoleAuth(userId, roles);
@@ -65,7 +65,7 @@ public class SessionEndpointsTest: IClassFixture<TestWebApplicationFactory<Progr
     {
         using var scope = _factory.Services.CreateScope();
         var sessionSub = scope.ServiceProvider.GetService<ISessionRepository>();
-    	sessionSub!.GetSessionsAsync(Arg.Any<int>()).Returns(new List<Session>{new Session{Title = "Hello"}}); 
+    	sessionSub!.GetInstructorSessionsAsync(Arg.Any<int>()).Returns(new List<Session>{new Session{Title = "Hello"}}); 
     	var userId = 1;
     	var roles = new List<Roles> { Roles.AnonymousUser};
     	_client.AddRoleAuth(userId, roles);

--- a/UnitTest/Core/Sessions/SessionServiceTest.cs
+++ b/UnitTest/Core/Sessions/SessionServiceTest.cs
@@ -80,9 +80,9 @@ public class SessionServiceTest
 
         var session1 = new Session();
         var session2 = new Session();
-        sessionRepoSub.GetSessionsAsync(Arg.Any<int>()).Returns(new List<Session> { session1, session2 });
+        sessionRepoSub.GetInstructorSessionsAsync(Arg.Any<int>()).Returns(new List<Session> { session1, session2 });
 
-        var result = await sessionService.GetSessions(1);
+        var result = await sessionService.GetSessions(1, Roles.Instructor);
         
         Assert.True(result.IsSuccess);
         Assert.Equal(2, result.Value.Count);
@@ -98,9 +98,9 @@ public class SessionServiceTest
         var classroomRepoSub = Substitute.For<IClassroomRepository>();
         var sessionService = new SessionService(sessionRepoSub, loggerSub, tokenRepoSub, classroomRepoSub);
 
-        sessionRepoSub.GetSessionsAsync(Arg.Any<int>()).Returns(Task.FromResult<IEnumerable<Session>?>(null));
+        sessionRepoSub.GetInstructorSessionsAsync(Arg.Any<int>()).Returns(Task.FromResult<List<Session>?>(null));
 
-        var result = await sessionService.GetSessions(1);
+        var result = await sessionService.GetSessions(1, Roles.Instructor);
         
         Assert.True(result.IsFailed);
     }


### PR DESCRIPTION
## Description
Makes multiple small adjustments requested by the frontend team.

## Changes
- When a user has already joined a session or classroom, the response is the same as if he joins. 
  - This now too includes id to what has been joined.
- Fixed an issue where student could not successfully request GET classrooms
- Fixed an issue where student got empty response when requesting GET sessions
- Adds so that student get timed_session id, if part of a timed session, when requesting GET user/id endpoint.

## Checklist

- [ ] I have added test cases for my additions
- [X] New and old tests passed
- [ ] Documentation is updated
