### PR TITLE
rename session properties, for consistency between session types.

### DIFF
--- a/Core/Classrooms/Models/GetClassroomSessionResponseDto.cs
+++ b/Core/Classrooms/Models/GetClassroomSessionResponseDto.cs
@@ -14,7 +14,8 @@ public class GetClassroomSessionResponseDto
     public int Id { get; set; }
     public string Title { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
-    public int Author { get; set; }
+    public int AuthorId { get; set; }
+    public string Author { get; set; } = string.Empty;
     public bool Active { get; set; }
     public List<SolvedExercise> Exercises { get; set; } = new ();
     public List<GetLanguagesResponseDto> Languages { get; set; } = new ();

--- a/Core/Classrooms/Models/GetClassroomSessionResponseDto.cs
+++ b/Core/Classrooms/Models/GetClassroomSessionResponseDto.cs
@@ -17,6 +17,6 @@ public class GetClassroomSessionResponseDto
     public int Author { get; set; }
     public bool Active { get; set; }
     public List<SolvedExercise> Exercises { get; set; } = new ();
-    public List<Language> Languages { get; set; } = new ();
+    public List<GetLanguagesResponseDto> Languages { get; set; } = new ();
 }
 

--- a/Core/Classrooms/Models/GetClassroomSessionResponseDto.cs
+++ b/Core/Classrooms/Models/GetClassroomSessionResponseDto.cs
@@ -17,7 +17,8 @@ public class GetClassroomSessionResponseDto
     public int AuthorId { get; set; }
     public string Author { get; set; } = string.Empty;
     public bool Active { get; set; }
-    public List<SolvedExercise> Exercises { get; set; } = new ();
+    public List<SolvedExerciseDto> Exercises { get; set; } = new ();
     public List<GetLanguagesResponseDto> Languages { get; set; } = new ();
 }
+
 

--- a/Core/Classrooms/Models/GetClassroomSessionResponseDto.cs
+++ b/Core/Classrooms/Models/GetClassroomSessionResponseDto.cs
@@ -14,9 +14,9 @@ public class GetClassroomSessionResponseDto
     public int Id { get; set; }
     public string Title { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
-    public int AuthorId { get; set; }
+    public int Author { get; set; }
     public bool Active { get; set; }
-    public List<SolvedExercise> ExerciseIds { get; set; } = new ();
+    public List<SolvedExercise> Exercises { get; set; } = new ();
     public List<Language> Languages { get; set; } = new ();
 }
 

--- a/Core/Solutions/Contracts/ISolutionRepository.cs
+++ b/Core/Solutions/Contracts/ISolutionRepository.cs
@@ -7,7 +7,7 @@ namespace Core.Solutions.Contracts;
 public interface ISolutionRepository
 {
 	Task<List<Testcase>?> GetTestCasesByExerciseIdAsync(int exerciseId);
-	Task<bool> CheckAnonUserExistsInSessionAsync(int userId, int sessionId);
+	Task<bool> CheckUserAssociationToSessionAsync(int userId, int sessionId);
 	Task<bool> InsertSolvedRelation(int userId, int exerciseId, int sessionId);
 	
 	Task<LanguageSupport?> GetSolutionLanguageBySession(int languageId, int sessionId);

--- a/Core/Solutions/SolutionRunnerService.cs
+++ b/Core/Solutions/SolutionRunnerService.cs
@@ -25,11 +25,11 @@ public class SolutionRunnerService : ISolutionRunnerService
     {
         // validate anon user is part of a given session
         // Short circuit if user is not part of the session
-        var userExistsInSession = await _solutionRepository.CheckAnonUserExistsInSessionAsync(userId, dto.SessionId);
+        var userExistsInSession = await _solutionRepository.CheckUserAssociationToSessionAsync(userId, dto.SessionId);
         if (!userExistsInSession)
         {
-            _logger.LogWarning("User {UserId} does not exist in Session {SessionId}", userId, dto.SessionId);
-            return Result.Fail($"User {userId} does not exist in the session.");
+            _logger.LogWarning("User {UserId} does not assocaited to Session {SessionId}", userId, dto.SessionId);
+            return Result.Fail($"User {userId} not associated to the session.");
         }
         // get selected language 
         var language = await _solutionRepository.GetSolutionLanguageBySession(dto.LanguageId, dto.SessionId);

--- a/Infrastructure/ClassroomRepository.cs
+++ b/Infrastructure/ClassroomRepository.cs
@@ -334,7 +334,7 @@ public class ClassroomRepository : IClassroomRepository
                         s.session_id AS id,
                         s.title AS title,
                         s.description AS description,
-                        s.author_id AS authorid,
+                        s.author_id AS author,
                         sic.active AS active
                     FROM session s
                     JOIN session_in_classroom sic ON sic.session_id = s.session_id
@@ -343,7 +343,7 @@ public class ClassroomRepository : IClassroomRepository
 
         var session = await con.QuerySingleAsync<GetClassroomSessionResponseDto>(query, new { SessionId = sessionId });
 
-        session.ExerciseIds = (await _sessionRepository.GetExercisesOfSessionAsync(sessionId, con));
+        session.Exercises = (await _sessionRepository.GetExercisesOfSessionAsync(sessionId, con));
 
         var languageQuery = "SELECT language_id FROM language_in_session WHERE session_id = @SessionId;";
 

--- a/Infrastructure/ClassroomRepository.cs
+++ b/Infrastructure/ClassroomRepository.cs
@@ -1,5 +1,6 @@
 ﻿using Core.Classrooms.Contracts;
 using Core.Classrooms.Models;
+using Core.Exercises.Models;
 using Core.Languages.Models;
 using Core.Sessions.Contracts;
 using Core.Sessions.Models;
@@ -345,7 +346,8 @@ public class ClassroomRepository : IClassroomRepository
 
         var session = await con.QuerySingleAsync<GetClassroomSessionResponseDto>(query, new { SessionId = sessionId });
 
-        session.Exercises = (await _sessionRepository.GetExercisesOfSessionAsync(sessionId, con));
+        var tempExercises = await _sessionRepository.GetExercisesOfSessionAsync(sessionId, con);
+        session.Exercises = tempExercises.Select(x => new SolvedExerciseDto(x.ExerciseId, x.ExerciseTitle, x.Solved)).ToList();
 
         var languageQuery = """
                             SELECT ls.language_id AS languageId, ls.language 

--- a/Infrastructure/ClassroomRepository.cs
+++ b/Infrastructure/ClassroomRepository.cs
@@ -334,10 +334,12 @@ public class ClassroomRepository : IClassroomRepository
                         s.session_id AS id,
                         s.title AS title,
                         s.description AS description,
-                        s.author_id AS author,
+                        s.author_id AS authorId,
+                        u.name AS author,
                         sic.active AS active
                     FROM session s
                     JOIN session_in_classroom sic ON sic.session_id = s.session_id
+                    JOIN users as u ON u.id = s.author_id
                     WHERE s.session_id = @SessionId
                     """;
 

--- a/Infrastructure/ClassroomRepository.cs
+++ b/Infrastructure/ClassroomRepository.cs
@@ -345,9 +345,15 @@ public class ClassroomRepository : IClassroomRepository
 
         session.Exercises = (await _sessionRepository.GetExercisesOfSessionAsync(sessionId, con));
 
-        var languageQuery = "SELECT language_id FROM language_in_session WHERE session_id = @SessionId;";
+        var languageQuery = """
+                            SELECT ls.language_id AS languageId, ls.language 
+                            FROM language_in_session AS lis
+                            JOIN language_support AS ls 
+                                ON lis.language_id = ls.language_id
+                            WHERE session_id = @SessionId;
+                            """;
 
-        var languages = await con.QueryAsync<Language>(languageQuery, new { SessionId = sessionId });
+        var languages = await con.QueryAsync<GetLanguagesResponseDto>(languageQuery, new { SessionId = sessionId });
         session.Languages = languages.ToList();
 
         return session;

--- a/IntegrationTest/ExerciseEndpointsTest.cs
+++ b/IntegrationTest/ExerciseEndpointsTest.cs
@@ -439,7 +439,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         var solutionRepoSub = scope.ServiceProvider.GetService<ISolutionRepository>();
         var mozartServiceSub = scope.ServiceProvider.GetService<IMozartService>();
 
-        solutionRepoSub.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+        solutionRepoSub.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         var language = new LanguageSupport { Id = 1 };
         solutionRepoSub.GetSolutionLanguageBySession(Arg.Any<int>(), Arg.Any<int>()).Returns(language);
         var testcasesResponse = new List<Testcase> { new Testcase { TestCaseId = 1, IsPublicVisible = true, Input = { new TestParameter { ParameterType = "int", ParameterValue = "1" } }, Output = { new TestParameter { ParameterType = "int", ParameterValue = "1" } } } };
@@ -465,7 +465,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         var solutionRepoSub = scope.ServiceProvider.GetService<ISolutionRepository>();
         var mozartServiceSub = scope.ServiceProvider.GetService<IMozartService>();
 
-        solutionRepoSub.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+        solutionRepoSub.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         var language = new LanguageSupport { Id = 2 };
         solutionRepoSub.GetSolutionLanguageBySession(Arg.Any<int>(), Arg.Any<int>()).Returns(language);
         var testcasesResponse = new List<Testcase> { new Testcase { TestCaseId = 1, IsPublicVisible = true, Input = { new TestParameter { ParameterType = "int", ParameterValue = "1" } }, Output = { new TestParameter { ParameterType = "int", ParameterValue = "1" } } } };
@@ -491,7 +491,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         var solutionRepoSub = scope.ServiceProvider.GetService<ISolutionRepository>();
         var mozartServiceSub = scope.ServiceProvider.GetService<IMozartService>();
 
-        solutionRepoSub!.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+        solutionRepoSub!.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         mozartServiceSub!.SubmitSubmission(Arg.Any<SubmissionDto>(), (Language)99)
             .Returns(Task.FromException<Result<SolutionRunnerResponse>>(
             new ArgumentOutOfRangeException("Invalid language")
@@ -514,7 +514,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         var solutionRepoSub = scope.ServiceProvider.GetService<ISolutionRepository>();
         var mozartServiceSub = scope.ServiceProvider.GetService<IMozartService>();
 
-        solutionRepoSub.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+        solutionRepoSub.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         var language = new LanguageSupport { Id = 1 };
         solutionRepoSub.GetSolutionLanguageBySession(Arg.Any<int>(), Arg.Any<int>()).Returns(language);
         var testcasesResponse = new List<Testcase> { new Testcase { TestCaseId = 1, IsPublicVisible = true, Input = { new TestParameter { ParameterType = "int", ParameterValue = "1" } }, Output = { new TestParameter { ParameterType = "int", ParameterValue = "1" } } } };
@@ -543,7 +543,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         var solutionRepoSub = scope.ServiceProvider.GetService<ISolutionRepository>();
         var mozartServiceSub = scope.ServiceProvider.GetService<IMozartService>();
 
-        solutionRepoSub.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(false);
+        solutionRepoSub.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(false);
         var testcasesResponse = new List<Testcase> { new Testcase { TestCaseId = 1, IsPublicVisible = true, Input = { new TestParameter { ParameterType = "int", ParameterValue = "1" } }, Output = { new TestParameter { ParameterType = "int", ParameterValue = "1" } } } };
         solutionRepoSub.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(testcasesResponse);
         var solutionRunnerResponse = new SolutionRunnerResponse { Action = ResponseCode.Pass };
@@ -567,7 +567,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         var solutionRepoSub = scope.ServiceProvider.GetService<ISolutionRepository>();
         var mozartServiceSub = scope.ServiceProvider.GetService<IMozartService>();
 
-        solutionRepoSub.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+        solutionRepoSub.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         var testcasesResponse = new List<Testcase> { new Testcase { TestCaseId = 1, IsPublicVisible = true, Input = { new TestParameter { ParameterType = "int", ParameterValue = "1" } }, Output = { new TestParameter { ParameterType = "int", ParameterValue = "1" } } } };
         solutionRepoSub.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(testcasesResponse);
         var solutionRunnerResponse = new SolutionRunnerResponse { Action = ResponseCode.Pass };

--- a/UnitTest/Core/Solutions/SolutionRunnerServiceTest.cs
+++ b/UnitTest/Core/Solutions/SolutionRunnerServiceTest.cs
@@ -34,7 +34,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnerService(loggerSub, solutionRepo, mozartService);
         var dto = new SubmitSolutionDto(1, "test", 1);
 
-        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(false);
+        solutionRepo.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(false);
 
         var result = await runner.SubmitSolutionAsync(dto, exerciseId: 1, userId: 2);
 
@@ -56,7 +56,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnerService(loggerSub, solutionRepo, mozartService);
         var dto = new SubmitSolutionDto(1, "test", 1);
 
-        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+        solutionRepo.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepo.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(Task.FromResult<List<Testcase>?>(null));
 
         var result = await runner.SubmitSolutionAsync(dto, exerciseId: 1, userId: 2);
@@ -79,7 +79,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnerService(loggerSub, solutionRepo, mozartService);
         var dto = new SubmitSolutionDto(1, "test", 1);
 
-        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+        solutionRepo.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepo.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(Task.FromResult<List<Testcase>?>(null));
         solutionRepo.GetSolutionLanguageBySession(Arg.Any<int>(), Arg.Any<int>()).Returns(new LanguageSupport());
 
@@ -103,7 +103,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnerService(loggerSub, solutionRepo, mozartService);
         var dto = new SubmitSolutionDto(1, "test", 1);
 
-        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+        solutionRepo.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         var language = new LanguageSupport { Id = 1 };
         solutionRepo.GetSolutionLanguageBySession(Arg.Any<int>(), Arg.Any<int>()).Returns(language);
         solutionRepo.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(Task.FromResult<List<Testcase>?>(new List<Testcase>()));
@@ -130,7 +130,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnerService(loggerSub, solutionRepo, mozartService);
         var dto = new SubmitSolutionDto(1, "test", 1);
 
-        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+        solutionRepo.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         var language = new LanguageSupport { Id = 1 };
         solutionRepo.GetSolutionLanguageBySession(Arg.Any<int>(), Arg.Any<int>()).Returns(language);
         solutionRepo.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(Task.FromResult<List<Testcase>?>(new List<Testcase>()));
@@ -158,7 +158,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnerService(loggerSub, solutionRepo, mozartService);
         var dto = new SubmitSolutionDto(1, "test", 1);
         
-        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+        solutionRepo.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         var language = new LanguageSupport { Id = 1 };
         solutionRepo.GetSolutionLanguageBySession(Arg.Any<int>(), Arg.Any<int>()).Returns(language);
         solutionRepo.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(Task.FromResult<List<Testcase>?>(new List<Testcase>()));
@@ -186,7 +186,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnerService(loggerSub, solutionRepo, mozartService);
         var dto = new SubmitSolutionDto(1, "test", 1);
 
-        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+        solutionRepo.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         var language = new LanguageSupport { Id = 1 };
         solutionRepo.GetSolutionLanguageBySession(Arg.Any<int>(), Arg.Any<int>()).Returns(language);
         solutionRepo.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(Task.FromResult<List<Testcase>?>(new List<Testcase>()));
@@ -213,7 +213,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnerService(loggerSub, solutionRepo, mozartService);
         var dto = new SubmitSolutionDto(1, "test", 1);
 
-        solutionRepo.CheckAnonUserExistsInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
+        solutionRepo.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         var language = new LanguageSupport { Id = 1 };
         solutionRepo.GetSolutionLanguageBySession(Arg.Any<int>(), Arg.Any<int>()).Returns(language);
         solutionRepo.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(Task.FromResult<List<Testcase>?>(new List<Testcase>()));


### PR DESCRIPTION
## Description
Renamed properties of classroom sessions, on request of frontend, to ensure consistent use.

## Checklist

- [ ] I have added test cases for my additions
- [X] New and old tests passed
- [ ] Documentation is updated
