### PR TITLE
Adds option for student to answer same exercise in classroom session and timed session; adds exercise/session validation for submission

### DIFF
--- a/Core/Solutions/Contracts/ISolutionRepository.cs
+++ b/Core/Solutions/Contracts/ISolutionRepository.cs
@@ -12,5 +12,4 @@ public interface ISolutionRepository
 	Task<LanguageSupport?> GetSolutionLanguageBySession(int languageId, int sessionId);
 	Task<bool> VerifyExerciseInSessionAsync(int sessionId, int exerciseId);
     Task<bool> InsertSubmissionRelation(Submission submission);
-
 }

--- a/Core/Solutions/Contracts/ISolutionRepository.cs
+++ b/Core/Solutions/Contracts/ISolutionRepository.cs
@@ -9,9 +9,8 @@ public interface ISolutionRepository
 	Task<List<Testcase>?> GetTestCasesByExerciseIdAsync(int exerciseId);
 	Task<bool> CheckUserAssociationToSessionAsync(int userId, int sessionId);
 	Task<bool> InsertSolvedRelation(int userId, int exerciseId, int sessionId);
-	
 	Task<LanguageSupport?> GetSolutionLanguageBySession(int languageId, int sessionId);
-
-	Task<bool> InsertSubmissionRelation(Submission submission);
+	Task<bool> VerifyExerciseInSessionAsync(int sessionId, int exerciseId);
+    Task<bool> InsertSubmissionRelation(Submission submission);
 
 }

--- a/Core/Solutions/SolutionRunnerService.cs
+++ b/Core/Solutions/SolutionRunnerService.cs
@@ -16,13 +16,18 @@ public class SolutionRunnerService : ISolutionRunnerService
     public SolutionRunnerService(ILogger<SolutionRunnerService> logger, ISolutionRepository solutionRepository, IMozartService iMozartService)
     {
         _logger = logger;
-        
         _solutionRepository = solutionRepository;
         _iMozartService = iMozartService;
     }
 
     public async Task<Result<string>> SubmitSolutionAsync(SubmitSolutionDto dto, int exerciseId, int userId)
     {
+        var exerciseInSession = await _solutionRepository.VerifyExerciseInSessionAsync(dto.SessionId, exerciseId);
+        if (!exerciseInSession)
+        {
+            _logger.LogWarning("User {UserId} atempted to solve Exercise {Exerciseid} not in Session {SessionId}", userId, exerciseId, dto.SessionId);
+            return Result.Fail("Exercise not in session");
+        }
         // validate anon user is part of a given session
         // Short circuit if user is not part of the session
         var userExistsInSession = await _solutionRepository.CheckUserAssociationToSessionAsync(userId, dto.SessionId);

--- a/Infrastructure/Persistence/Scripts/002-V2Migrations.sql
+++ b/Infrastructure/Persistence/Scripts/002-V2Migrations.sql
@@ -36,6 +36,11 @@ ALTER TABLE submission
     ADD COLUMN solution TEXT,
     ADD COLUMN language_id INTEGER REFERENCES language_support(language_id) NOT NULL DEFAULT 9999999,
     ADD COLUMN solved BOOLEAN NOT NULL DEFAULT false;
+BEGIN;
+ALTER TABLE submission DROP CONSTRAINT solved_pkey;
+ALTER TABLE submission ADD CONSTRAINT solved_pkey PRIMARY KEY (user_id, exercise_id, session_id);
+COMMIT;
+
 
 CREATE TABLE language_in_session (
     session_id INTEGER REFERENCES session(session_id) ON DELETE CASCADE,

--- a/Infrastructure/SolutionRepository.cs
+++ b/Infrastructure/SolutionRepository.cs
@@ -191,6 +191,16 @@ public class SolutionRepository : ISolutionRepository
 		return true;
 	}
 	
+	public async Task<bool> VerifyExerciseInSessionAsync(int sessionId, int exerciseId)
+	{
+		using var con = await _dbConnection.CreateConnectionAsync();
+
+		var query = "SELECT COUNT(*) FROM exercise_in_session WHERE session_id = @SessionId AND exercise_id = @ExerciseId";
+
+		var result = await con.QuerySingleAsync<int>(query, new { SessionId = sessionId, ExerciseId = exerciseId });
+
+		return result > 0;
+	}
 	
 	public async Task<bool> InsertSolvedRelation(int userId, int exerciseId, int sessionId)
 	{

--- a/IntegrationTest/ExerciseEndpointsTest.cs
+++ b/IntegrationTest/ExerciseEndpointsTest.cs
@@ -439,6 +439,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         var solutionRepoSub = scope.ServiceProvider.GetService<ISolutionRepository>();
         var mozartServiceSub = scope.ServiceProvider.GetService<IMozartService>();
 
+        solutionRepoSub.VerifyExerciseInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepoSub.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         var language = new LanguageSupport { Id = 1 };
         solutionRepoSub.GetSolutionLanguageBySession(Arg.Any<int>(), Arg.Any<int>()).Returns(language);
@@ -465,6 +466,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         var solutionRepoSub = scope.ServiceProvider.GetService<ISolutionRepository>();
         var mozartServiceSub = scope.ServiceProvider.GetService<IMozartService>();
 
+        solutionRepoSub.VerifyExerciseInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepoSub.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         var language = new LanguageSupport { Id = 2 };
         solutionRepoSub.GetSolutionLanguageBySession(Arg.Any<int>(), Arg.Any<int>()).Returns(language);
@@ -491,6 +493,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         var solutionRepoSub = scope.ServiceProvider.GetService<ISolutionRepository>();
         var mozartServiceSub = scope.ServiceProvider.GetService<IMozartService>();
 
+        solutionRepoSub.VerifyExerciseInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepoSub!.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         mozartServiceSub!.SubmitSubmission(Arg.Any<SubmissionDto>(), (Language)99)
             .Returns(Task.FromException<Result<SolutionRunnerResponse>>(
@@ -514,6 +517,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         var solutionRepoSub = scope.ServiceProvider.GetService<ISolutionRepository>();
         var mozartServiceSub = scope.ServiceProvider.GetService<IMozartService>();
 
+        solutionRepoSub.VerifyExerciseInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepoSub.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         var language = new LanguageSupport { Id = 1 };
         solutionRepoSub.GetSolutionLanguageBySession(Arg.Any<int>(), Arg.Any<int>()).Returns(language);
@@ -543,6 +547,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         var solutionRepoSub = scope.ServiceProvider.GetService<ISolutionRepository>();
         var mozartServiceSub = scope.ServiceProvider.GetService<IMozartService>();
 
+        solutionRepoSub.VerifyExerciseInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepoSub.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(false);
         var testcasesResponse = new List<Testcase> { new Testcase { TestCaseId = 1, IsPublicVisible = true, Input = { new TestParameter { ParameterType = "int", ParameterValue = "1" } }, Output = { new TestParameter { ParameterType = "int", ParameterValue = "1" } } } };
         solutionRepoSub.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(testcasesResponse);
@@ -567,6 +572,7 @@ public class ExerciseEndpointsTest : IClassFixture<TestWebApplicationFactory<Pro
         var solutionRepoSub = scope.ServiceProvider.GetService<ISolutionRepository>();
         var mozartServiceSub = scope.ServiceProvider.GetService<IMozartService>();
 
+        solutionRepoSub.VerifyExerciseInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepoSub.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         var testcasesResponse = new List<Testcase> { new Testcase { TestCaseId = 1, IsPublicVisible = true, Input = { new TestParameter { ParameterType = "int", ParameterValue = "1" } }, Output = { new TestParameter { ParameterType = "int", ParameterValue = "1" } } } };
         solutionRepoSub.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(testcasesResponse);

--- a/UnitTest/Core/Solutions/SolutionRunnerServiceTest.cs
+++ b/UnitTest/Core/Solutions/SolutionRunnerServiceTest.cs
@@ -8,6 +8,7 @@ using Core.Solutions.Contracts;
 using Core.Solutions.Models;
 using Core.Solutions.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestPlatform.Common.Interfaces;
 using NSubstitute;
 using UnitTest.Core.Exercises;
 
@@ -17,6 +18,29 @@ public class SolutionRunnerServiceTest
 {
     private readonly ILogger<SolutionRunnerService> loggerSub = Substitute.For<ILogger<SolutionRunnerService>>();
     private readonly ILogger<MozartService> mozartLoggerSub = Substitute.For<ILogger<MozartService>>();
+
+    [Fact]
+    public async Task SubmitSolutionAsync_ShouldReturn_FailExerciseNotInSession()
+    {
+        Environment.SetEnvironmentVariable("MOZART_HASKELL", "url");
+        var response = new HttpResponseMessage
+        {
+            StatusCode = HttpStatusCode.OK,
+            Content = new StringContent("{\"Result\": \"error\"}", Encoding.UTF8, "application/json")
+        };
+        var httpClientSub = new MockHttpMessageHandler(response);
+        var client = new HttpClient(httpClientSub);
+        var solutionRepo = Substitute.For<ISolutionRepository>();
+        var mozartService = new MozartService(client, mozartLoggerSub);
+        var runner = new SolutionRunnerService(loggerSub, solutionRepo, mozartService);
+        var dto = new SubmitSolutionDto(1, "test", 1);
+
+        solutionRepo.VerifyExerciseInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(false);
+
+        var result = await runner.SubmitSolutionAsync(dto, exerciseId: 1, userId: 2);
+
+        Assert.True(result.IsFailed);
+    }
 
     [Fact]
     public async Task SubmitSolutionAsync_ShouldReturn_FailUserNotInSession()
@@ -34,6 +58,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnerService(loggerSub, solutionRepo, mozartService);
         var dto = new SubmitSolutionDto(1, "test", 1);
 
+        solutionRepo.VerifyExerciseInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepo.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(false);
 
         var result = await runner.SubmitSolutionAsync(dto, exerciseId: 1, userId: 2);
@@ -56,6 +81,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnerService(loggerSub, solutionRepo, mozartService);
         var dto = new SubmitSolutionDto(1, "test", 1);
 
+        solutionRepo.VerifyExerciseInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepo.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepo.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(Task.FromResult<List<Testcase>?>(null));
 
@@ -79,6 +105,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnerService(loggerSub, solutionRepo, mozartService);
         var dto = new SubmitSolutionDto(1, "test", 1);
 
+        solutionRepo.VerifyExerciseInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepo.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepo.GetTestCasesByExerciseIdAsync(Arg.Any<int>()).Returns(Task.FromResult<List<Testcase>?>(null));
         solutionRepo.GetSolutionLanguageBySession(Arg.Any<int>(), Arg.Any<int>()).Returns(new LanguageSupport());
@@ -103,6 +130,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnerService(loggerSub, solutionRepo, mozartService);
         var dto = new SubmitSolutionDto(1, "test", 1);
 
+        solutionRepo.VerifyExerciseInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepo.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         var language = new LanguageSupport { Id = 1 };
         solutionRepo.GetSolutionLanguageBySession(Arg.Any<int>(), Arg.Any<int>()).Returns(language);
@@ -130,6 +158,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnerService(loggerSub, solutionRepo, mozartService);
         var dto = new SubmitSolutionDto(1, "test", 1);
 
+        solutionRepo.VerifyExerciseInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepo.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         var language = new LanguageSupport { Id = 1 };
         solutionRepo.GetSolutionLanguageBySession(Arg.Any<int>(), Arg.Any<int>()).Returns(language);
@@ -158,6 +187,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnerService(loggerSub, solutionRepo, mozartService);
         var dto = new SubmitSolutionDto(1, "test", 1);
         
+        solutionRepo.VerifyExerciseInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepo.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         var language = new LanguageSupport { Id = 1 };
         solutionRepo.GetSolutionLanguageBySession(Arg.Any<int>(), Arg.Any<int>()).Returns(language);
@@ -186,6 +216,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnerService(loggerSub, solutionRepo, mozartService);
         var dto = new SubmitSolutionDto(1, "test", 1);
 
+        solutionRepo.VerifyExerciseInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepo.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         var language = new LanguageSupport { Id = 1 };
         solutionRepo.GetSolutionLanguageBySession(Arg.Any<int>(), Arg.Any<int>()).Returns(language);
@@ -213,6 +244,7 @@ public class SolutionRunnerServiceTest
         var runner = new SolutionRunnerService(loggerSub, solutionRepo, mozartService);
         var dto = new SubmitSolutionDto(1, "test", 1);
 
+        solutionRepo.VerifyExerciseInSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         solutionRepo.CheckUserAssociationToSessionAsync(Arg.Any<int>(), Arg.Any<int>()).Returns(true);
         var language = new LanguageSupport { Id = 1 };
         solutionRepo.GetSolutionLanguageBySession(Arg.Any<int>(), Arg.Any<int>()).Returns(language);


### PR DESCRIPTION
## Changes
- Modifies primary key of submission to allow a submission to exist of the same student for the same exercise, in both timed and classroom session.
- Create validation step to ensure exercise exist in a session.
- Modifes excisting testcases to include the validation step.
- Adds a single unit test to validate the new validation can fail.

## Checklist

- [X] I have added test cases for my additions
- [X] New and old tests passed
- [ ] Documentation is updated
